### PR TITLE
fix: VULN-3698 address vulnerability in okio library

### DIFF
--- a/key-vault/hashicorp-key-vault/build.gradle
+++ b/key-vault/hashicorp-key-vault/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   implementation("org.springframework.vault:spring-vault-core:2.3.2") {
     exclude group: "org.springframework",module: "spring-core"
   }
-  implementation "com.squareup.okhttp3:okhttp:3.12.3"
+  implementation "com.squareup.okhttp3:okhttp:4.9.2"
 
   implementation "org.springframework:spring-orm:$springVersion"
   testImplementation "org.springframework:spring-test:$springVersion"


### PR DESCRIPTION
## PR Description
This is to fix vulnerability (CVE-2023-3635) detected in com.squareup.okio:okio:1.15 library in `hashicorp-key-vault` modile. More details about the vulnerability here https://avd.aquasec.com/nvd/cve-2023-3635

## Fixed Issue(s)
- To  fix vulnerability (CVE-2023-3635) com.squareup.okio:okio::3.12.3 library was upgraded to 4.9.2  in `hashicorp-key-vault`

## Documentation
- Documentation is not required to be updated
