### PR TITLE
Tessera does not consistently connect to all peers in the network in Recovery mode

### DIFF
--- a/tessera-dist/src/main/java/com/quorum/tessera/launcher/Launcher.java
+++ b/tessera-dist/src/main/java/com/quorum/tessera/launcher/Launcher.java
@@ -86,7 +86,7 @@ public enum Launcher {
 
       final ServerConfig recoveryP2PServer = config.getP2PServerConfig();
       final IntervalPropertyHelper intervalPropertyHelper =
-        new IntervalPropertyHelper(config.getP2PServerConfig().getProperties());
+          new IntervalPropertyHelper(config.getP2PServerConfig().getProperties());
 
       final Object app =
           ServiceLoader.load(TesseraApp.class).stream()
@@ -119,8 +119,11 @@ public enum Launcher {
       recoveryServer.start();
       LOGGER.debug("Started recovery server");
 
-      final var waitTimeBeforeRecoveryStartsInMillis = intervalPropertyHelper.partyInfoInterval() * 2L;
-      LOGGER.info("Waiting for nodes to synchronise with peers for {} seconds", waitTimeBeforeRecoveryStartsInMillis / 1000L);
+      final var waitTimeBeforeRecoveryStartsInMillis =
+          intervalPropertyHelper.partyInfoInterval() * 2L;
+      LOGGER.info(
+          "Waiting for nodes to synchronise with peers for {} seconds",
+          waitTimeBeforeRecoveryStartsInMillis / 1000L);
       Thread.sleep(waitTimeBeforeRecoveryStartsInMillis);
 
       final int exitCode = Recovery.create().recover();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/tessera/blob/master/.github/CONTRIBUTING.md -->

## Fixes the Issue where Node is not able to consistently connect to peers during recovery mode

In recovery mode, Tessera waits for 10 seconds before initiating the main recovery procedure. This 10-second value is currently hard-coded. However, if a peer's partyInfoInterval exceeds 10 seconds, the node in recovery may not provide sufficient time for peers to inform it about the peer's party info. Consequently, there is a risk that the recovery node might consider the peer inactive.

To address this issue, the 10-second wait time should be adjusted dynamically to twice the partyInfoInterval. This adjustment ensures that recovery nodes and their peers have adequate time to synchronize their partyInfo, enhancing the accuracy and reliability of the recovery process.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
- SET-530

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
