### PR TITLE
SET-544 implemented reading Hashicorp Vault secret with TSE

### DIFF
--- a/config/src/main/java/com/quorum/tessera/config/KeyData.java
+++ b/config/src/main/java/com/quorum/tessera/config/KeyData.java
@@ -45,6 +45,10 @@ public class KeyData extends ConfigItem {
 
   @XmlElement private String hashicorpVaultSecretEngineName;
 
+  @XmlElement private String hashicorpVaultTransitSecretEngineName;
+
+  @XmlElement private String hashicorpVaultTransitKeyName;
+
   @XmlElement private String hashicorpVaultSecretName;
 
   @XmlElement private String hashicorpVaultSecretVersion;
@@ -70,6 +74,47 @@ public class KeyData extends ConfigItem {
       String hashicorpVaultSecretVersion,
       String awsSecretsManagerPublicKeyId,
       String awsSecretsManagerPrivateKeyId) {
+    this(
+      config,
+      privateKey,
+      publicKey,
+      privateKeyPath,
+      publicKeyPath,
+      azureVaultPublicKeyId,
+      azureVaultPrivateKeyId,
+      azureVaultPublicKeyVersion,
+      azureVaultPrivateKeyVersion,
+      hashicorpVaultPublicKeyId,
+      hashicorpVaultPrivateKeyId,
+      hashicorpVaultSecretEngineName,
+      hashicorpVaultSecretName,
+      hashicorpVaultSecretVersion,
+      "",
+      "",
+      awsSecretsManagerPublicKeyId,
+      awsSecretsManagerPrivateKeyId
+    );
+  }
+
+  public KeyData(
+    KeyDataConfig config,
+    String privateKey,
+    String publicKey,
+    Path privateKeyPath,
+    Path publicKeyPath,
+    String azureVaultPublicKeyId,
+    String azureVaultPrivateKeyId,
+    String azureVaultPublicKeyVersion,
+    String azureVaultPrivateKeyVersion,
+    String hashicorpVaultPublicKeyId,
+    String hashicorpVaultPrivateKeyId,
+    String hashicorpVaultSecretEngineName,
+    String hashicorpVaultSecretName,
+    String hashicorpVaultSecretVersion,
+    String hashicorpVaultTransitSecretEngineName,
+    String hashicorpVaultTransitKeyName,
+    String awsSecretsManagerPublicKeyId,
+    String awsSecretsManagerPrivateKeyId) {
     this.config = config;
     this.privateKey = privateKey;
     this.publicKey = publicKey;
@@ -83,6 +128,8 @@ public class KeyData extends ConfigItem {
     this.hashicorpVaultPrivateKeyId = hashicorpVaultPrivateKeyId;
     this.hashicorpVaultSecretEngineName = hashicorpVaultSecretEngineName;
     this.hashicorpVaultSecretName = hashicorpVaultSecretName;
+    this.hashicorpVaultTransitSecretEngineName = hashicorpVaultTransitSecretEngineName;
+    this.hashicorpVaultTransitKeyName = hashicorpVaultTransitKeyName;
     this.hashicorpVaultSecretVersion = hashicorpVaultSecretVersion;
     this.awsSecretsManagerPublicKeyId = awsSecretsManagerPublicKeyId;
     this.awsSecretsManagerPrivateKeyId = awsSecretsManagerPrivateKeyId;
@@ -146,6 +193,10 @@ public class KeyData extends ConfigItem {
     return hashicorpVaultSecretVersion;
   }
 
+  public String getHashicorpVaultTransitSecretEngineName() { return hashicorpVaultTransitSecretEngineName; }
+
+  public String getHashicorpVaultTransitKeyName() { return hashicorpVaultTransitKeyName; }
+
   public String getAwsSecretsManagerPublicKeyId() {
     return awsSecretsManagerPublicKeyId;
   }
@@ -208,6 +259,14 @@ public class KeyData extends ConfigItem {
 
   public void setHashicorpVaultSecretVersion(String hashicorpVaultSecretVersion) {
     this.hashicorpVaultSecretVersion = hashicorpVaultSecretVersion;
+  }
+
+  public void setHashicorpVaultTransitSecretEngineName(String hashicorpVaultTransitSecretEngineName){
+    this.hashicorpVaultTransitSecretEngineName = hashicorpVaultTransitSecretEngineName;
+  }
+
+  public void setHashicorpVaultTransitKeyName(String hashicorpVaultTransitKeyName){
+    this.hashicorpVaultTransitKeyName = hashicorpVaultTransitKeyName;
   }
 
   public void setAwsSecretsManagerPublicKeyId(String awsSecretsManagerPublicKeyId) {

--- a/config/src/main/java/com/quorum/tessera/config/KeyData.java
+++ b/config/src/main/java/com/quorum/tessera/config/KeyData.java
@@ -72,49 +72,10 @@ public class KeyData extends ConfigItem {
       String hashicorpVaultSecretEngineName,
       String hashicorpVaultSecretName,
       String hashicorpVaultSecretVersion,
+      String hashicorpVaultTransitSecretEngineName,
+      String hashicorpVaultTransitKeyName,
       String awsSecretsManagerPublicKeyId,
       String awsSecretsManagerPrivateKeyId) {
-    this(
-      config,
-      privateKey,
-      publicKey,
-      privateKeyPath,
-      publicKeyPath,
-      azureVaultPublicKeyId,
-      azureVaultPrivateKeyId,
-      azureVaultPublicKeyVersion,
-      azureVaultPrivateKeyVersion,
-      hashicorpVaultPublicKeyId,
-      hashicorpVaultPrivateKeyId,
-      hashicorpVaultSecretEngineName,
-      hashicorpVaultSecretName,
-      hashicorpVaultSecretVersion,
-      "",
-      "",
-      awsSecretsManagerPublicKeyId,
-      awsSecretsManagerPrivateKeyId
-    );
-  }
-
-  public KeyData(
-    KeyDataConfig config,
-    String privateKey,
-    String publicKey,
-    Path privateKeyPath,
-    Path publicKeyPath,
-    String azureVaultPublicKeyId,
-    String azureVaultPrivateKeyId,
-    String azureVaultPublicKeyVersion,
-    String azureVaultPrivateKeyVersion,
-    String hashicorpVaultPublicKeyId,
-    String hashicorpVaultPrivateKeyId,
-    String hashicorpVaultSecretEngineName,
-    String hashicorpVaultSecretName,
-    String hashicorpVaultSecretVersion,
-    String hashicorpVaultTransitSecretEngineName,
-    String hashicorpVaultTransitKeyName,
-    String awsSecretsManagerPublicKeyId,
-    String awsSecretsManagerPrivateKeyId) {
     this.config = config;
     this.privateKey = privateKey;
     this.publicKey = publicKey;
@@ -193,9 +154,13 @@ public class KeyData extends ConfigItem {
     return hashicorpVaultSecretVersion;
   }
 
-  public String getHashicorpVaultTransitSecretEngineName() { return hashicorpVaultTransitSecretEngineName; }
+  public String getHashicorpVaultTransitSecretEngineName() {
+    return hashicorpVaultTransitSecretEngineName;
+  }
 
-  public String getHashicorpVaultTransitKeyName() { return hashicorpVaultTransitKeyName; }
+  public String getHashicorpVaultTransitKeyName() {
+    return hashicorpVaultTransitKeyName;
+  }
 
   public String getAwsSecretsManagerPublicKeyId() {
     return awsSecretsManagerPublicKeyId;
@@ -261,11 +226,12 @@ public class KeyData extends ConfigItem {
     this.hashicorpVaultSecretVersion = hashicorpVaultSecretVersion;
   }
 
-  public void setHashicorpVaultTransitSecretEngineName(String hashicorpVaultTransitSecretEngineName){
+  public void setHashicorpVaultTransitSecretEngineName(
+      String hashicorpVaultTransitSecretEngineName) {
     this.hashicorpVaultTransitSecretEngineName = hashicorpVaultTransitSecretEngineName;
   }
 
-  public void setHashicorpVaultTransitKeyName(String hashicorpVaultTransitKeyName){
+  public void setHashicorpVaultTransitKeyName(String hashicorpVaultTransitKeyName) {
     this.hashicorpVaultTransitKeyName = hashicorpVaultTransitKeyName;
   }
 

--- a/config/src/main/java/com/quorum/tessera/config/keypairs/HashicorpVaultKeyPair.java
+++ b/config/src/main/java/com/quorum/tessera/config/keypairs/HashicorpVaultKeyPair.java
@@ -14,6 +14,10 @@ public class HashicorpVaultKeyPair implements ConfigKeyPair {
 
   @NotNull @XmlElement private String secretName;
 
+  @NotNull @XmlElement private String transitSecretEngineName;
+
+  @NotNull @XmlElement private String transitKeyName;
+
   @PositiveOrZero(message = "{ValidPositiveInteger.message}")
   @XmlElement
   private Integer secretVersion;
@@ -24,11 +28,32 @@ public class HashicorpVaultKeyPair implements ConfigKeyPair {
       String secretEngineName,
       String secretName,
       Integer secretVersion) {
+    this(
+      publicKeyId,
+      privateKeyId,
+      secretEngineName,
+      secretName,
+      secretVersion,
+      "",
+      ""
+    );
+  }
+
+  public HashicorpVaultKeyPair(
+    String publicKeyId,
+    String privateKeyId,
+    String secretEngineName,
+    String secretName,
+    Integer secretVersion,
+    String transitSecretEngineName,
+    String transitKeyName) {
     this.publicKeyId = publicKeyId;
     this.privateKeyId = privateKeyId;
     this.secretEngineName = secretEngineName;
     this.secretName = secretName;
     this.secretVersion = secretVersion;
+    this.transitSecretEngineName = transitSecretEngineName;
+    this.transitKeyName = transitKeyName;
   }
 
   public String getPublicKeyId() {
@@ -45,6 +70,14 @@ public class HashicorpVaultKeyPair implements ConfigKeyPair {
 
   public String getSecretName() {
     return secretName;
+  }
+
+  public String getTransitSecretEngineName() {
+    return transitSecretEngineName;
+  }
+
+  public String getTransitKeyName() {
+    return transitKeyName;
   }
 
   public Integer getSecretVersion() {

--- a/config/src/main/java/com/quorum/tessera/config/keypairs/HashicorpVaultKeyPair.java
+++ b/config/src/main/java/com/quorum/tessera/config/keypairs/HashicorpVaultKeyPair.java
@@ -14,9 +14,9 @@ public class HashicorpVaultKeyPair implements ConfigKeyPair {
 
   @NotNull @XmlElement private String secretName;
 
-  @NotNull @XmlElement private String transitSecretEngineName;
+  @XmlElement private String transitSecretEngineName;
 
-  @NotNull @XmlElement private String transitKeyName;
+  @XmlElement private String transitKeyName;
 
   @PositiveOrZero(message = "{ValidPositiveInteger.message}")
   @XmlElement
@@ -28,25 +28,17 @@ public class HashicorpVaultKeyPair implements ConfigKeyPair {
       String secretEngineName,
       String secretName,
       Integer secretVersion) {
-    this(
-      publicKeyId,
-      privateKeyId,
-      secretEngineName,
-      secretName,
-      secretVersion,
-      "",
-      ""
-    );
+    this(publicKeyId, privateKeyId, secretEngineName, secretName, secretVersion, "", "");
   }
 
   public HashicorpVaultKeyPair(
-    String publicKeyId,
-    String privateKeyId,
-    String secretEngineName,
-    String secretName,
-    Integer secretVersion,
-    String transitSecretEngineName,
-    String transitKeyName) {
+      String publicKeyId,
+      String privateKeyId,
+      String secretEngineName,
+      String secretName,
+      Integer secretVersion,
+      String transitSecretEngineName,
+      String transitKeyName) {
     this.publicKeyId = publicKeyId;
     this.privateKeyId = privateKeyId;
     this.secretEngineName = secretEngineName;

--- a/config/src/main/java/com/quorum/tessera/config/keypairs/UnsupportedKeyPair.java
+++ b/config/src/main/java/com/quorum/tessera/config/keypairs/UnsupportedKeyPair.java
@@ -42,6 +42,10 @@ public class UnsupportedKeyPair implements ConfigKeyPair {
 
   @XmlElement private String hashicorpVaultSecretVersion;
 
+  @XmlElement private String hashicorpVaultTransitSecretEngine;
+
+  @XmlElement private String hashicorpVaultTransitKey;
+
   @XmlElement private String awsSecretsManagerPublicKeyId;
 
   @XmlElement private String awsSecretsManagerPrivateKeyId;
@@ -61,6 +65,8 @@ public class UnsupportedKeyPair implements ConfigKeyPair {
       String hashicorpVaultSecretEngineName,
       String hashicorpVaultSecretName,
       String hashicorpVaultSecretVersion,
+      String hashicorpVaultTransitSecretEngine,
+      String hashicorpVaultTransitKey,
       String awsSecretsManagerPublicKeyId,
       String awsSecretsManagerPrivateKeyId) {
     this.config = config;
@@ -77,6 +83,8 @@ public class UnsupportedKeyPair implements ConfigKeyPair {
     this.hashicorpVaultSecretEngineName = hashicorpVaultSecretEngineName;
     this.hashicorpVaultSecretName = hashicorpVaultSecretName;
     this.hashicorpVaultSecretVersion = hashicorpVaultSecretVersion;
+    this.hashicorpVaultTransitSecretEngine = hashicorpVaultTransitSecretEngine;
+    this.hashicorpVaultTransitKey = hashicorpVaultTransitKey;
     this.awsSecretsManagerPublicKeyId = awsSecretsManagerPublicKeyId;
     this.awsSecretsManagerPrivateKeyId = awsSecretsManagerPrivateKeyId;
   }
@@ -139,6 +147,14 @@ public class UnsupportedKeyPair implements ConfigKeyPair {
 
   public String getHashicorpVaultSecretVersion() {
     return hashicorpVaultSecretVersion;
+  }
+
+  public String getHashicorpVaultTransitSecretEngine() {
+    return hashicorpVaultTransitSecretEngine;
+  }
+
+  public String getHashicorpVaultTransitKey() {
+    return hashicorpVaultTransitKey;
   }
 
   @Override
@@ -205,6 +221,14 @@ public class UnsupportedKeyPair implements ConfigKeyPair {
 
   public void setHashicorpVaultSecretVersion(String hashicorpVaultSecretVersion) {
     this.hashicorpVaultSecretVersion = hashicorpVaultSecretVersion;
+  }
+
+  public void setHashicorpVaultTransitSecretEngine(String hashicorpVaultTransitSecretEngine) {
+    this.hashicorpVaultTransitSecretEngine = hashicorpVaultTransitSecretEngine;
+  }
+
+  public void setHashicorpVaultTransitKey(String hashicorpVaultTransitKey) {
+    this.hashicorpVaultTransitKey = hashicorpVaultTransitKey;
   }
 
   public String getAwsSecretsManagerPublicKeyId() {

--- a/config/src/main/java/com/quorum/tessera/config/util/KeyDataUtil.java
+++ b/config/src/main/java/com/quorum/tessera/config/util/KeyDataUtil.java
@@ -168,7 +168,9 @@ public class KeyDataUtil {
           keyData.getHashicorpVaultPrivateKeyId(),
           keyData.getHashicorpVaultSecretEngineName(),
           keyData.getHashicorpVaultSecretName(),
-          hashicorpVaultSecretVersion);
+          hashicorpVaultSecretVersion,
+          keyData.getHashicorpVaultTransitSecretEngineName(),
+          keyData.getHashicorpVaultTransitKeyName());
     }
 
     // case 5, the AWS Secrets Manager data is provided

--- a/config/src/main/java/com/quorum/tessera/config/util/KeyDataUtil.java
+++ b/config/src/main/java/com/quorum/tessera/config/util/KeyDataUtil.java
@@ -204,6 +204,8 @@ public class KeyDataUtil {
         keyData.getHashicorpVaultSecretEngineName(),
         keyData.getHashicorpVaultSecretName(),
         keyData.getHashicorpVaultSecretVersion(),
+        keyData.getHashicorpVaultTransitSecretEngineName(),
+        keyData.getHashicorpVaultTransitKeyName(),
         keyData.getAwsSecretsManagerPublicKeyId(),
         keyData.getAwsSecretsManagerPrivateKeyId());
   }
@@ -278,6 +280,8 @@ public class KeyDataUtil {
           kp.getHashicorpVaultSecretEngineName(),
           kp.getHashicorpVaultSecretName(),
           kp.getHashicorpVaultSecretVersion(),
+          kp.getHashicorpVaultTransitSecretEngine(),
+          kp.getHashicorpVaultTransitKey(),
           kp.getAwsSecretsManagerPublicKeyId(),
           kp.getAwsSecretsManagerPrivateKeyId());
     }

--- a/config/src/test/java/com/quorum/tessera/config/keypairs/UnsupportedKeyPairTest.java
+++ b/config/src/test/java/com/quorum/tessera/config/keypairs/UnsupportedKeyPairTest.java
@@ -14,7 +14,7 @@ public class UnsupportedKeyPairTest {
     this.keyPair =
         new UnsupportedKeyPair(
             null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-            null, null);
+            null, null, null, null);
   }
 
   @Test

--- a/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/KeyPairConverter.java
+++ b/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/KeyPairConverter.java
@@ -67,14 +67,18 @@ public class KeyPairConverter {
               "secretEngineName", hkp.getSecretEngineName(),
               "secretName", hkp.getSecretName(),
               "secretId", hkp.getPublicKeyId(),
-              "secretVersion", Objects.toString(hkp.getSecretVersion()));
+              "secretVersion", Objects.toString(hkp.getSecretVersion()),
+              "transitSecretEngineName", hkp.getTransitSecretEngineName(),
+              "transitKeyName", hkp.getTransitKeyName());
 
       Map<String, String> getPrivateKeyData =
           Map.of(
               "secretEngineName", hkp.getSecretEngineName(),
               "secretName", hkp.getSecretName(),
               "secretId", hkp.getPrivateKeyId(),
-              "secretVersion", Objects.toString(hkp.getSecretVersion()));
+              "secretVersion", Objects.toString(hkp.getSecretVersion()),
+              "transitSecretEngineName", hkp.getTransitSecretEngineName(),
+              "transitKeyName", hkp.getTransitKeyName());
 
       base64PublicKey = keyVaultService.getSecret(getPublicKeyData);
       base64PrivateKey = keyVaultService.getSecret(getPrivateKeyData);

--- a/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/KeyPairConverter.java
+++ b/enclave/enclave-api/src/main/java/com/quorum/tessera/enclave/KeyPairConverter.java
@@ -68,8 +68,8 @@ public class KeyPairConverter {
               "secretName", hkp.getSecretName(),
               "secretId", hkp.getPublicKeyId(),
               "secretVersion", Objects.toString(hkp.getSecretVersion()),
-              "transitSecretEngineName", hkp.getTransitSecretEngineName(),
-              "transitKeyName", hkp.getTransitKeyName());
+              "transitSecretEngineName", Objects.toString(hkp.getTransitSecretEngineName(), ""),
+              "transitKeyName", Objects.toString(hkp.getTransitKeyName(), ""));
 
       Map<String, String> getPrivateKeyData =
           Map.of(
@@ -77,8 +77,8 @@ public class KeyPairConverter {
               "secretName", hkp.getSecretName(),
               "secretId", hkp.getPrivateKeyId(),
               "secretVersion", Objects.toString(hkp.getSecretVersion()),
-              "transitSecretEngineName", hkp.getTransitSecretEngineName(),
-              "transitKeyName", hkp.getTransitKeyName());
+              "transitSecretEngineName", Objects.toString(hkp.getTransitSecretEngineName(), ""),
+              "transitKeyName", Objects.toString(hkp.getTransitKeyName(), ""));
 
       base64PublicKey = keyVaultService.getSecret(getPublicKeyData);
       base64PrivateKey = keyVaultService.getSecret(getPrivateKeyData);

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultService.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultService.java
@@ -91,7 +91,7 @@ public class HashicorpKeyVaultService implements KeyVaultService {
     String secretName = hashicorpSetSecretData.get(SECRET_NAME_KEY);
     String secretEngineName = hashicorpSetSecretData.get(SECRET_ENGINE_NAME_KEY);
 
-    final var propertyKeysToFilterOut =
+    final var propertiesToExcludeFromSavingToVaultSecret =
         List.of(
             SECRET_NAME_KEY,
             SECRET_ID_KEY,
@@ -101,7 +101,7 @@ public class HashicorpKeyVaultService implements KeyVaultService {
 
     Map<String, String> nameValuePairs =
         hashicorpSetSecretData.entrySet().stream()
-            .filter(not(e -> propertyKeysToFilterOut.contains(e.getKey())))
+            .filter(not(e -> propertiesToExcludeFromSavingToVaultSecret.contains(e.getKey())))
             .map(e -> encryptValueIfTseRequired(hashicorpSetSecretData, e))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultService.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultService.java
@@ -7,6 +7,7 @@ import com.quorum.tessera.key.vault.SetSecretResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.springframework.vault.core.VaultOperations;
@@ -35,13 +36,24 @@ public class HashicorpKeyVaultService implements KeyVaultService {
 
   HashicorpKeyVaultService(
       VaultOperations vaultOperations,
-      Supplier<VaultVersionedKeyValueTemplateFactory>
-          vaultVersionedKeyValueTemplateFactorySupplier) {
+      Supplier<VaultVersionedKeyValueTemplateFactory> vaultVersionedKeyValueTemplateFactorySupplier,
+      Function<VaultOperations, HashicorpTransitSecretEngineService>
+          hashicorpTransitSecretEngineServiceProvider) {
     this.vaultOperations = vaultOperations;
     this.vaultVersionedKeyValueTemplateFactory =
         vaultVersionedKeyValueTemplateFactorySupplier.get();
     this.hashicorpTransitSecretEngineService =
-        new HashicorpTransitSecretEngineService(this.vaultOperations);
+        hashicorpTransitSecretEngineServiceProvider.apply(this.vaultOperations);
+  }
+
+  HashicorpKeyVaultService(
+      VaultOperations vaultOperations,
+      Supplier<VaultVersionedKeyValueTemplateFactory>
+          vaultVersionedKeyValueTemplateFactorySupplier) {
+    this(
+        vaultOperations,
+        vaultVersionedKeyValueTemplateFactorySupplier,
+        HashicorpTransitSecretEngineService::new);
   }
 
   @Override

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpTransitSecretEngineService.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpTransitSecretEngineService.java
@@ -1,0 +1,83 @@
+package com.quorum.tessera.key.vault.hashicorp;
+
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.vault.core.VaultOperations;
+import org.springframework.vault.core.VaultTransitTemplate;
+
+class HashicorpTransitSecretEngineService {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(HashicorpTransitSecretEngineService.class);
+  private final VaultOperations vaultOperations;
+
+  HashicorpTransitSecretEngineService(VaultOperations vaultOperations) {
+    this.vaultOperations = vaultOperations;
+  }
+
+  private VaultTransitTemplate createVaultTransitTemplate(String transitSecretEngineName) {
+    return new VaultTransitTemplate(vaultOperations, transitSecretEngineName);
+  }
+
+  private boolean validateIfValueIsTobeDecryptedByTse(
+      String transitSecretEngineName, String transitKeyName, String value) {
+    if (value != null && value.startsWith("vault:v")) {
+      if (transitSecretEngineName == null || transitSecretEngineName.isEmpty()) {
+        throw new HashicorpVaultException(
+            "Value needs to be decrypted, but \""
+                + HashicorpKeyVaultService.TRANSIT_SECRET_ENGINE_NAME_KEY
+                + "\" property is not provided");
+      }
+      if (transitKeyName == null || transitKeyName.isEmpty()) {
+        throw new HashicorpVaultException(
+            "Value needs to be decrypted, but \""
+                + HashicorpKeyVaultService.TRANSIT_KEY_NAME_KEY
+                + "\" property is not provided");
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private boolean validateIfValueNeedsToBeEncryptedByTse(
+      String transitSecretEngineName, String transitKeyName, String value) {
+    if (transitSecretEngineName != null
+        && !transitSecretEngineName.isEmpty()
+        && transitKeyName != null
+        && !transitKeyName.isEmpty()
+        && value != null
+        && !value.isEmpty()) {
+      return true;
+    }
+    return false;
+  }
+
+  String decryptValueIfTseRequired(Map<String, String> hashicorpGetSecretData, String value) {
+    String transitSecretEngineName =
+        hashicorpGetSecretData.get(HashicorpKeyVaultService.TRANSIT_SECRET_ENGINE_NAME_KEY);
+    String transitKeyName =
+        hashicorpGetSecretData.get(HashicorpKeyVaultService.TRANSIT_KEY_NAME_KEY);
+    if (validateIfValueIsTobeDecryptedByTse(transitSecretEngineName, transitKeyName, value)) {
+      var vaultTransitTemplate = createVaultTransitTemplate(transitSecretEngineName);
+      var decryptedValue = vaultTransitTemplate.decrypt(transitKeyName, value);
+      LOGGER.info("Value decrypted successfully using TSE");
+      return decryptedValue;
+    }
+    return value;
+  }
+
+  String encryptValueIfTseRequired(Map<String, String> hashicorpGetSecretData, String value) {
+    String transitSecretEngineName =
+        hashicorpGetSecretData.get(HashicorpKeyVaultService.TRANSIT_SECRET_ENGINE_NAME_KEY);
+    String transitKeyName =
+        hashicorpGetSecretData.get(HashicorpKeyVaultService.TRANSIT_KEY_NAME_KEY);
+    if (validateIfValueNeedsToBeEncryptedByTse(transitSecretEngineName, transitKeyName, value)) {
+      var vaultTransitTemplate = createVaultTransitTemplate(transitSecretEngineName);
+      var encryptedValue = vaultTransitTemplate.encrypt(transitKeyName, value);
+      LOGGER.info("Value encrypted successfully using TSE");
+      return encryptedValue;
+    }
+    return value;
+  }
+}

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpTransitSecretEngineService.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpTransitSecretEngineService.java
@@ -47,15 +47,12 @@ class HashicorpTransitSecretEngineService {
 
   private boolean validateIfValueNeedsToBeEncryptedByTse(
       String transitSecretEngineName, String transitKeyName, String value) {
-    if (transitSecretEngineName != null
+    return transitSecretEngineName != null
         && !transitSecretEngineName.isEmpty()
         && transitKeyName != null
         && !transitKeyName.isEmpty()
         && value != null
-        && !value.isEmpty()) {
-      return true;
-    }
-    return false;
+        && !value.isEmpty();
   }
 
   String decryptValueIfTseRequired(Map<String, String> hashicorpGetSecretData, String value) {

--- a/key-vault/hashicorp-key-vault/src/test/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceTest.java
+++ b/key-vault/hashicorp-key-vault/src/test/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceTest.java
@@ -8,7 +8,9 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.vault.core.VaultOperations;
+import org.springframework.vault.core.VaultTransitTemplate;
 import org.springframework.vault.core.VaultVersionedKeyValueTemplate;
 import org.springframework.vault.support.Versioned;
 
@@ -19,6 +21,8 @@ public class HashicorpKeyVaultServiceTest {
   private VaultOperations vaultOperations;
 
   private VaultVersionedKeyValueTemplateFactory vaultVersionedKeyValueTemplateFactory;
+
+  private HashicorpTransitSecretEngineService hashicorpTransitSecretEngineService;
 
   @Before
   public void beforeTest() {
@@ -209,5 +213,255 @@ public class HashicorpKeyVaultServiceTest {
 
     verify(vaultVersionedKeyValueTemplateFactory)
         .createVaultVersionedKeyValueTemplate(vaultOperations, "SomeEngineName");
+  }
+
+  @Test
+  public void
+      givenTransitSecretEngineConfigurationAreAvailable_andKVDataWasEncryptedByTSE_thenKVDataAreDecryptedByTSEFirstBeforeReturningIt() {
+    String encryptedKeyValue = "vault:v1:encrypted value";
+    String decryptedKeyValue = "decrypted data";
+
+    var mockedVaultTransitTemplate = mock(VaultTransitTemplate.class);
+    when(mockedVaultTransitTemplate.decrypt(anyString(), anyString()))
+        .thenReturn(decryptedKeyValue);
+
+    this.hashicorpTransitSecretEngineService =
+        spy(new HashicorpTransitSecretEngineService(vaultOperations));
+    doReturn(mockedVaultTransitTemplate)
+        .when(this.hashicorpTransitSecretEngineService)
+        .createVaultTransitTemplate(anyString());
+
+    var keyVaultUsingTseService =
+        new HashicorpKeyVaultService(
+            vaultOperations,
+            () -> vaultVersionedKeyValueTemplateFactory,
+            (v) -> this.hashicorpTransitSecretEngineService);
+
+    Map<String, String> getSecretData =
+        Map.of(
+            HashicorpKeyVaultService.SECRET_ENGINE_NAME_KEY, "secretEngine",
+            HashicorpKeyVaultService.SECRET_NAME_KEY, "secretName",
+            HashicorpKeyVaultService.SECRET_ID_KEY, "keyId",
+            HashicorpKeyVaultService.TRANSIT_SECRET_ENGINE_NAME_KEY, "transit",
+            HashicorpKeyVaultService.TRANSIT_KEY_NAME_KEY, "my-key");
+
+    Versioned versionedResponse = mock(Versioned.class);
+
+    when(versionedResponse.hasData()).thenReturn(true);
+
+    VaultVersionedKeyValueTemplate vaultVersionedKeyValueTemplate =
+        mock(VaultVersionedKeyValueTemplate.class);
+    when(vaultVersionedKeyValueTemplate.get("secretName", Versioned.Version.from(0)))
+        .thenReturn(versionedResponse);
+
+    when(vaultVersionedKeyValueTemplateFactory.createVaultVersionedKeyValueTemplate(
+            vaultOperations, "secretEngine"))
+        .thenReturn(vaultVersionedKeyValueTemplate);
+
+    Map responseData = Map.of("keyId", encryptedKeyValue);
+    when(versionedResponse.getData()).thenReturn(responseData);
+
+    String result = keyVaultUsingTseService.getSecret(getSecretData);
+    assertThat(result).isEqualTo(decryptedKeyValue);
+
+    verify(vaultVersionedKeyValueTemplateFactory)
+        .createVaultVersionedKeyValueTemplate(vaultOperations, "secretEngine");
+  }
+
+  @Test
+  public void
+      givenKVDataWasEncryptedByTSE_butTransitSecretEngineConfigurationAreMissing_thenShouldThrowHashicorpVaultException() {
+    String encryptedKeyValue = "vault:v1:encrypted value";
+    String decryptedKeyValue = "decrypted data";
+
+    var mockedVaultTransitTemplate = mock(VaultTransitTemplate.class);
+    when(mockedVaultTransitTemplate.decrypt(anyString(), anyString()))
+        .thenReturn(decryptedKeyValue);
+
+    this.hashicorpTransitSecretEngineService =
+        spy(new HashicorpTransitSecretEngineService(vaultOperations));
+    doReturn(mockedVaultTransitTemplate)
+        .when(this.hashicorpTransitSecretEngineService)
+        .createVaultTransitTemplate(anyString());
+
+    var keyVaultUsingTseService =
+        new HashicorpKeyVaultService(
+            vaultOperations,
+            () -> vaultVersionedKeyValueTemplateFactory,
+            (v) -> this.hashicorpTransitSecretEngineService);
+
+    Map<String, String> getSecretData =
+        Map.of(
+            HashicorpKeyVaultService.SECRET_ENGINE_NAME_KEY, "secretEngine",
+            HashicorpKeyVaultService.SECRET_NAME_KEY, "secretName",
+            HashicorpKeyVaultService.SECRET_ID_KEY, "keyId");
+
+    Versioned versionedResponse = mock(Versioned.class);
+
+    when(versionedResponse.hasData()).thenReturn(true);
+
+    VaultVersionedKeyValueTemplate vaultVersionedKeyValueTemplate =
+        mock(VaultVersionedKeyValueTemplate.class);
+    when(vaultVersionedKeyValueTemplate.get("secretName", Versioned.Version.from(0)))
+        .thenReturn(versionedResponse);
+
+    when(vaultVersionedKeyValueTemplateFactory.createVaultVersionedKeyValueTemplate(
+            vaultOperations, "secretEngine"))
+        .thenReturn(vaultVersionedKeyValueTemplate);
+
+    Map responseData = Map.of("keyId", encryptedKeyValue);
+    when(versionedResponse.getData()).thenReturn(responseData);
+
+    Throwable ex = catchThrowable(() -> keyVaultUsingTseService.getSecret(getSecretData));
+
+    assertThat(ex).isExactlyInstanceOf(HashicorpVaultException.class);
+    assertThat(ex)
+        .hasMessage(
+            "Vault key value needs to be decrypted, but the following configuration was/were not provided: [ transitSecretEngineName, transitKeyName ]");
+
+    verify(vaultVersionedKeyValueTemplateFactory)
+        .createVaultVersionedKeyValueTemplate(vaultOperations, "secretEngine");
+  }
+
+  @Test
+  public void
+      givenTransitSecretEngineConfigurationAreAvailable_thenPrivateAndPublicKeyShouldBeTSEEncryptedBeforeStoredInKV() {
+    String plainTextPublicKey = "plain text public key";
+    String plainTextPrivateKey = "plain text private key";
+    String encryptedPublicKey = "encrypted public key";
+    String encryptedPrivateKey = "encrypted private key";
+    String transitKeyName = "my-key";
+
+    var mockedVaultTransitTemplate = mock(VaultTransitTemplate.class);
+    when(mockedVaultTransitTemplate.encrypt(transitKeyName, plainTextPublicKey))
+        .thenReturn(encryptedPublicKey);
+    when(mockedVaultTransitTemplate.encrypt(transitKeyName, plainTextPrivateKey))
+        .thenReturn(encryptedPrivateKey);
+
+    this.hashicorpTransitSecretEngineService =
+        spy(new HashicorpTransitSecretEngineService(vaultOperations));
+    doReturn(mockedVaultTransitTemplate)
+        .when(this.hashicorpTransitSecretEngineService)
+        .createVaultTransitTemplate(anyString());
+
+    var keyVaultUsingTseService =
+        new HashicorpKeyVaultService(
+            vaultOperations,
+            () -> vaultVersionedKeyValueTemplateFactory,
+            (v) -> this.hashicorpTransitSecretEngineService);
+
+    Map<String, String> setSecretData =
+        Map.of(
+            HashicorpKeyVaultService.SECRET_ENGINE_NAME_KEY,
+            "engine",
+            HashicorpKeyVaultService.SECRET_NAME_KEY,
+            "name",
+            HashicorpKeyVaultService.TRANSIT_SECRET_ENGINE_NAME_KEY,
+            "transit",
+            HashicorpKeyVaultService.TRANSIT_KEY_NAME_KEY,
+            transitKeyName,
+            "publicKey",
+            plainTextPublicKey,
+            "privateKey",
+            plainTextPrivateKey);
+
+    Versioned.Metadata metadata = mock(Versioned.Metadata.class);
+    VaultVersionedKeyValueTemplate vaultVersionedKeyValueTemplate =
+        mock(VaultVersionedKeyValueTemplate.class);
+    when(vaultVersionedKeyValueTemplate.put(eq("name"), anyMap())).thenReturn(metadata);
+
+    when(vaultVersionedKeyValueTemplateFactory.createVaultVersionedKeyValueTemplate(
+            vaultOperations, "engine"))
+        .thenReturn(vaultVersionedKeyValueTemplate);
+
+    Versioned.Version version = mock(Versioned.Version.class);
+    when(version.getVersion()).thenReturn(22);
+
+    when(metadata.getVersion()).thenReturn(version);
+
+    SetSecretResponse result = keyVaultUsingTseService.setSecret(setSecretData);
+
+    assertThat(result.getProperties()).size().isEqualTo(1);
+    assertThat(result.getProperties()).contains(entry("version", "22"));
+
+    var argCapture = ArgumentCaptor.forClass(Object.class);
+    verify(vaultVersionedKeyValueTemplate).put(eq("name"), argCapture.capture());
+    var capturedArgument = (Map<String, String>) argCapture.getValue();
+
+    assertThat(capturedArgument.get("publicKey")).isEqualTo(encryptedPublicKey);
+    assertThat(capturedArgument.get("privateKey")).isEqualTo(encryptedPrivateKey);
+
+    verify(vaultVersionedKeyValueTemplateFactory)
+        .createVaultVersionedKeyValueTemplate(vaultOperations, "engine");
+  }
+
+  @Test
+  public void
+      givenTransitSecretEngineConfigurationAreMissing_thenPrivateAndPublicKeyShouldBeStoredInKVWithoutTSEEncyption() {
+    String plainTextPublicKey = "plain text public key";
+    String plainTextPrivateKey = "plain text private key";
+    String encryptedPublicKey = "encrypted public key";
+    String encryptedPrivateKey = "encrypted private key";
+    String transitKeyName = "my-key";
+
+    var mockedVaultTransitTemplate = mock(VaultTransitTemplate.class);
+    when(mockedVaultTransitTemplate.encrypt(transitKeyName, plainTextPublicKey))
+        .thenReturn(encryptedPublicKey);
+    when(mockedVaultTransitTemplate.encrypt(transitKeyName, plainTextPrivateKey))
+        .thenReturn(encryptedPrivateKey);
+
+    this.hashicorpTransitSecretEngineService =
+        spy(new HashicorpTransitSecretEngineService(vaultOperations));
+    doReturn(mockedVaultTransitTemplate)
+        .when(this.hashicorpTransitSecretEngineService)
+        .createVaultTransitTemplate(anyString());
+
+    var keyVaultUsingTseService =
+        new HashicorpKeyVaultService(
+            vaultOperations,
+            () -> vaultVersionedKeyValueTemplateFactory,
+            (v) -> this.hashicorpTransitSecretEngineService);
+
+    Map<String, String> setSecretData =
+        Map.of(
+            HashicorpKeyVaultService.SECRET_ENGINE_NAME_KEY,
+            "engine",
+            HashicorpKeyVaultService.SECRET_NAME_KEY,
+            "name",
+            HashicorpKeyVaultService.TRANSIT_KEY_NAME_KEY,
+            transitKeyName,
+            "publicKey",
+            plainTextPublicKey,
+            "privateKey",
+            plainTextPrivateKey);
+
+    Versioned.Metadata metadata = mock(Versioned.Metadata.class);
+    VaultVersionedKeyValueTemplate vaultVersionedKeyValueTemplate =
+        mock(VaultVersionedKeyValueTemplate.class);
+    when(vaultVersionedKeyValueTemplate.put(eq("name"), anyMap())).thenReturn(metadata);
+
+    when(vaultVersionedKeyValueTemplateFactory.createVaultVersionedKeyValueTemplate(
+            vaultOperations, "engine"))
+        .thenReturn(vaultVersionedKeyValueTemplate);
+
+    Versioned.Version version = mock(Versioned.Version.class);
+    when(version.getVersion()).thenReturn(22);
+
+    when(metadata.getVersion()).thenReturn(version);
+
+    SetSecretResponse result = keyVaultUsingTseService.setSecret(setSecretData);
+
+    assertThat(result.getProperties()).size().isEqualTo(1);
+    assertThat(result.getProperties()).contains(entry("version", "22"));
+
+    var argCapture = ArgumentCaptor.forClass(Object.class);
+    verify(vaultVersionedKeyValueTemplate).put(eq("name"), argCapture.capture());
+    var capturedArgument = (Map<String, String>) argCapture.getValue();
+
+    assertThat(capturedArgument.get("publicKey")).isEqualTo(plainTextPublicKey);
+    assertThat(capturedArgument.get("privateKey")).isEqualTo(plainTextPrivateKey);
+
+    verify(vaultVersionedKeyValueTemplateFactory)
+        .createVaultVersionedKeyValueTemplate(vaultOperations, "engine");
   }
 }

--- a/key-vault/hashicorp-key-vault/src/test/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceTest.java
+++ b/key-vault/hashicorp-key-vault/src/test/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceTest.java
@@ -217,7 +217,7 @@ public class HashicorpKeyVaultServiceTest {
 
   @Test
   public void
-      givenTransitSecretEngineConfigurationAreAvailable_andKVDataWasEncryptedByTSE_thenKVDataAreDecryptedByTSEFirstBeforeReturningIt() {
+      givenTransitSecretEngineConfigurationAreAvailableAndKVDataWasEncryptedByTseThenKVDataAreDecryptedByTseFirstBeforeReturningIt() {
     String encryptedKeyValue = "vault:v1:encrypted value";
     String decryptedKeyValue = "decrypted data";
 
@@ -270,7 +270,7 @@ public class HashicorpKeyVaultServiceTest {
 
   @Test
   public void
-      givenKVDataWasEncryptedByTSE_butTransitSecretEngineConfigurationAreMissing_thenShouldThrowHashicorpVaultException() {
+      givenKVDataWasEncryptedByTseButTransitSecretEngineConfigurationAreMissingThenShouldThrowHashicorpVaultException() {
     String encryptedKeyValue = "vault:v1:encrypted value";
     String decryptedKeyValue = "decrypted data";
 
@@ -325,7 +325,7 @@ public class HashicorpKeyVaultServiceTest {
 
   @Test
   public void
-      givenTransitSecretEngineConfigurationAreAvailable_thenPrivateAndPublicKeyShouldBeTSEEncryptedBeforeStoredInKV() {
+      givenTransitSecretEngineConfigurationAreAvailableThenPrivateAndPublicKeyShouldBeTseEncryptedBeforeStoredInKV() {
     String plainTextPublicKey = "plain text public key";
     String plainTextPrivateKey = "plain text private key";
     String encryptedPublicKey = "encrypted public key";
@@ -397,7 +397,7 @@ public class HashicorpKeyVaultServiceTest {
 
   @Test
   public void
-      givenTransitSecretEngineConfigurationAreMissing_thenPrivateAndPublicKeyShouldBeStoredInKVWithoutTSEEncyption() {
+      givenTransitSecretEngineConfigurationAreMissingThenPrivateAndPublicKeyShouldBeStoredInKvWithoutTseEncyption() {
     String plainTextPublicKey = "plain text public key";
     String plainTextPrivateKey = "plain text private key";
     String encryptedPublicKey = "encrypted public key";

--- a/tests/acceptance-test/src/test/resources/features/vault/hashicorp.feature
+++ b/tests/acceptance-test/src/test/resources/features/vault/hashicorp.feature
@@ -5,6 +5,8 @@ Feature: Hashicorp Vault support
         Given the vault server has been started with TLS-enabled
         And the vault is initialised and unsealed
         And the vault has a v2 kv secret engine
+        And the vault has a transit secret engine
+        And the vault has transit secret key
 
     Scenario: Tessera retrieves a key pair from the Vault using the Token auth method
         Given the vault contains a key pair
@@ -37,6 +39,16 @@ Feature: Hashicorp Vault support
             -configfile %s -pidfile %s -o jdbc.autoCreateTables=true
             """
         Then Tessera will retrieve the key pair from the vault
+
+    Scenario: Tessera retrieves a key pair from the Vault using the custom AppRole auth method when TSE configuration is defined
+      Given the vault contains a key pair encrypted by TSE
+      And the AppRole auth method is enabled at the default path
+      And the configfile contains the correct vault and TSE configuration
+      When Tessera is started with the following CLI args, configuration with TSE and approle environment variables
+      """
+      -configfile %s -pidfile %s -o jdbc.autoCreateTables=true
+      """
+      Then Tessera will retrieve the key pair from the vault
 
     Scenario: Tessera generates and stores a keypair in the Vault using the Token auth method
         When Tessera keygen is run with the following CLI args and token environment variable

--- a/tests/acceptance-test/src/test/resources/vault/tessera-hashicorp-approle-with-tse-config.json
+++ b/tests/acceptance-test/src/test/resources/vault/tessera-hashicorp-approle-with-tse-config.json
@@ -1,0 +1,46 @@
+{
+    "useWhiteList": false,
+    "jdbc": {
+        "username": "sa",
+        "password": "",
+        "url": "jdbc:h2:./build/h2/rest1;MODE=Oracle;TRACE_LEVEL_SYSTEM_OUT=0;AUTO_SERVER=TRUE;AUTO_SERVER_PORT=9090"
+    },
+    "serverConfigs": [
+        {
+            "app": "Q2T",
+            "enabled": true,
+            "serverAddress": "http://localhost:18080",
+            "communicationType": "REST"
+        },
+        {
+            "app": "P2P",
+            "enabled": true,
+            "serverAddress": "http://localhost:8080",
+            "communicationType": "REST"
+        }
+    ],
+    "peer": [
+        {
+            "url": "http://localhost:8081/"
+        }
+    ],
+    "keys": {
+        "passwords": [],
+        "hashicorpKeyVaultConfig": {
+            "url": "https://localhost:8200",
+            "tlsKeyStorePath": "${clientKeystore}",
+            "tlsTrustStorePath": "${clientTruststore}"
+        },
+        "keyData": [
+            {
+                "hashicorpVaultSecretEngineName": "kv",
+                "hashicorpVaultSecretName": "tessera",
+                "hashicorpVaultPublicKeyId": "publicKey",
+                "hashicorpVaultPrivateKeyId": "privateKey",
+                "hashicorpVaultTransitSecretEngineName": "transit",
+                "hashicorpVaultTransitKeyName": "tessera-tse-key"
+            }
+        ]
+    },
+    "alwaysSendTo": []
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/tessera/blob/master/.github/CONTRIBUTING.md -->

## PR Description
implemented reading Hashicorp Vault secret with TSE.
Two new configuration property introduced:
- hashicorpVaultTransitSecretEngineName
- hashicorpVaultTransitKeyName

Example config section:
```
      "keyData": [
        {
          "hashicorpVaultSecretEngineName": "secret",
          "hashicorpVaultSecretName": "tessera",
          "hashicorpVaultPrivateKeyId": "privateKey",
          "hashicorpVaultPublicKeyId": "publicKey",
          "hashicorpVaultTransitSecretEngineName": "transit",
          "hashicorpVaultTransitKeyName": "my-key"
        }
      ]
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
implemented reading Hashicorp Vault secret with TSE

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
