### PR TITLE
Support DB credential storage and password rotation via Hashicorp Vault

### DIFF
--- a/config/src/main/java/com/quorum/tessera/config/ConfigException.java
+++ b/config/src/main/java/com/quorum/tessera/config/ConfigException.java
@@ -5,4 +5,8 @@ public class ConfigException extends RuntimeException {
   public ConfigException(final Throwable cause) {
     super(cause);
   }
+
+  public ConfigException(final String message) {
+    super(message);
+  }
 }

--- a/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
@@ -132,7 +132,7 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     this.credentialType = credentialType;
   }
 
-  public DefaultKeyVaultConfig toKeyVaultConfig(){
+  public DefaultKeyVaultConfig toKeyVaultConfig() {
     DefaultKeyVaultConfig config = new DefaultKeyVaultConfig();
     config.setKeyVaultType(this.getKeyVaultType());
     config.setProperty("url", this.getUrl());
@@ -142,18 +142,18 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     config.setProperty("credentialType", this.getCredentialType());
 
     Optional.ofNullable(this.getTlsKeyStorePath())
-      .map(Objects::toString)
-      .ifPresent(
-        v -> {
-          config.setProperty("tlsKeyStorePath", v);
-        });
+        .map(Objects::toString)
+        .ifPresent(
+            v -> {
+              config.setProperty("tlsKeyStorePath", v);
+            });
 
     Optional.ofNullable(this.getTlsTrustStorePath())
-      .map(Objects::toString)
-      .ifPresent(
-        v -> {
-          config.setProperty("tlsTrustStorePath", v);
-        });
+        .map(Objects::toString)
+        .ifPresent(
+            v -> {
+              config.setProperty("tlsTrustStorePath", v);
+            });
 
     return config;
   }

--- a/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
@@ -25,6 +25,8 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
 
   @Valid @NotNull @XmlElement private String vaultDbRole;
 
+  @Valid @XmlElement private String credentialType;
+
   @Valid
   @ValidPath(checkExists = true, message = "File does not exist")
   @XmlElement(type = String.class)
@@ -122,6 +124,14 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     return KeyVaultType.HASHICORP;
   }
 
+  public String getCredentialType() {
+    return credentialType;
+  }
+
+  public void setCredentialType(String credentialType) {
+    this.credentialType = credentialType;
+  }
+
   public DefaultKeyVaultConfig toKeyVaultConfig(){
     DefaultKeyVaultConfig config = new DefaultKeyVaultConfig();
     config.setKeyVaultType(this.getKeyVaultType());
@@ -129,6 +139,7 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     config.setProperty("approlePath", this.getApprolePath());
     config.setProperty("dbSecretEngineName", this.getDbSecretEngineName());
     config.setProperty("vaultDbRole", this.getVaultDbRole());
+    config.setProperty("credentialType", this.getCredentialType());
 
     Optional.ofNullable(this.getTlsKeyStorePath())
       .map(Objects::toString)

--- a/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
@@ -1,0 +1,149 @@
+package com.quorum.tessera.config;
+
+import com.quorum.tessera.config.adapters.PathAdapter;
+import com.quorum.tessera.config.constraints.ValidPath;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
+
+  @Valid @NotNull @XmlElement private String url;
+
+  @Valid @XmlElement private String namespace;
+
+  @Valid @XmlElement private String approlePath;
+
+  @Valid @NotNull @XmlElement private String dbSecretEngineName;
+
+  @Valid @NotNull @XmlElement private String vaultDbRole;
+
+  @Valid
+  @ValidPath(checkExists = true, message = "File does not exist")
+  @XmlElement(type = String.class)
+  @XmlJavaTypeAdapter(PathAdapter.class)
+  private Path tlsKeyStorePath;
+
+  @Valid
+  @ValidPath(checkExists = true, message = "File does not exist")
+  @XmlElement(type = String.class)
+  @XmlJavaTypeAdapter(PathAdapter.class)
+  private Path tlsTrustStorePath;
+
+  public HashicorpVaultDbCredentialsConfig(
+      String url,
+      String namespace,
+      String approlePath,
+      String dbSecretEngineName,
+      String vaultDbRole,
+      Path tlsKeyStorePath,
+      Path tlsTrustStorePath) {
+    this.url = url;
+    this.namespace = namespace;
+    this.approlePath = approlePath;
+    this.dbSecretEngineName = dbSecretEngineName;
+    this.vaultDbRole = vaultDbRole;
+    this.tlsKeyStorePath = tlsKeyStorePath;
+    this.tlsTrustStorePath = tlsTrustStorePath;
+  }
+
+  public HashicorpVaultDbCredentialsConfig() {}
+
+  public String getUrl() {
+    return this.url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public void setNamespace(String namespace) {
+    this.namespace = namespace;
+  }
+
+  public String getDbSecretEngineName() {
+    if (dbSecretEngineName == null) {
+      return "database";
+    }
+    return dbSecretEngineName;
+  }
+
+  public void setDbSecretEngineName(String dbSecretEngineName) {
+    this.dbSecretEngineName = dbSecretEngineName;
+  }
+
+  public String getVaultDbRole() {
+    return vaultDbRole;
+  }
+
+  public void setVaultDbRole(String vaultDbRole) {
+    this.vaultDbRole = vaultDbRole;
+  }
+
+  public Path getTlsKeyStorePath() {
+    return tlsKeyStorePath;
+  }
+
+  public void setTlsKeyStorePath(Path tlsKeyStorePath) {
+    this.tlsKeyStorePath = tlsKeyStorePath;
+  }
+
+  public Path getTlsTrustStorePath() {
+    return tlsTrustStorePath;
+  }
+
+  public void setTlsTrustStorePath(Path tlsTrustStorePath) {
+    this.tlsTrustStorePath = tlsTrustStorePath;
+  }
+
+  public String getApprolePath() {
+    if (approlePath == null) {
+      return "approle";
+    }
+    return approlePath;
+  }
+
+  public void setApprolePath(String approlePath) {
+    this.approlePath = approlePath;
+  }
+
+  public KeyVaultType getKeyVaultType() {
+    return KeyVaultType.HASHICORP;
+  }
+
+  public DefaultKeyVaultConfig toKeyVaultConfig(){
+    DefaultKeyVaultConfig config = new DefaultKeyVaultConfig();
+    config.setKeyVaultType(this.getKeyVaultType());
+    config.setProperty("url", this.getUrl());
+    config.setProperty("approlePath", this.getApprolePath());
+    config.setProperty("dbSecretEngineName", this.getDbSecretEngineName());
+    config.setProperty("vaultDbRole", this.getVaultDbRole());
+
+    Optional.ofNullable(this.getTlsKeyStorePath())
+      .map(Objects::toString)
+      .ifPresent(
+        v -> {
+          config.setProperty("tlsKeyStorePath", v);
+        });
+
+    Optional.ofNullable(this.getTlsTrustStorePath())
+      .map(Objects::toString)
+      .ifPresent(
+        v -> {
+          config.setProperty("tlsTrustStorePath", v);
+        });
+
+    return config;
+  }
+}

--- a/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
@@ -45,20 +45,26 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
   @Valid @XmlElement private String delayBeforeNextRunFactor;
   @Valid @XmlElement private String maxDurationBeforeTtlExpireInSeconds;
 
-  public HashicorpVaultDbCredentialsConfig(HashicorpVaultDbCredentialsConfig config) {
-    this.url = config.url;
-    this.namespace = config.namespace;
-    this.approlePath = config.approlePath;
-    this.dbSecretEngineName = config.dbSecretEngineName;
-    this.vaultDbRole = config.vaultDbRole;
-    this.credentialType = config.credentialType;
-    this.tlsKeyStorePath = config.tlsKeyStorePath;
-    this.tlsTrustStorePath = config.tlsTrustStorePath;
-    this.retryDelayInSeconds = config.retryDelayInSeconds;
-    this.maxRetryDelayInSeconds = config.maxRetryDelayInSeconds;
-    this.minDelayBeforeNextRunInSeconds = config.minDelayBeforeNextRunInSeconds;
-    this.delayBeforeNextRunFactor = config.delayBeforeNextRunFactor;
-    this.maxDurationBeforeTtlExpireInSeconds = config.maxDurationBeforeTtlExpireInSeconds;
+  public static HashicorpVaultDbCredentialsConfig clone(
+      HashicorpVaultDbCredentialsConfig instance) {
+    if (instance == null) {
+      return null;
+    }
+    var newInstance = new HashicorpVaultDbCredentialsConfig();
+    newInstance.url = instance.url;
+    newInstance.namespace = instance.namespace;
+    newInstance.approlePath = instance.approlePath;
+    newInstance.dbSecretEngineName = instance.dbSecretEngineName;
+    newInstance.vaultDbRole = instance.vaultDbRole;
+    newInstance.credentialType = instance.credentialType;
+    newInstance.tlsKeyStorePath = instance.tlsKeyStorePath;
+    newInstance.tlsTrustStorePath = instance.tlsTrustStorePath;
+    newInstance.retryDelayInSeconds = instance.retryDelayInSeconds;
+    newInstance.maxRetryDelayInSeconds = instance.maxRetryDelayInSeconds;
+    newInstance.minDelayBeforeNextRunInSeconds = instance.minDelayBeforeNextRunInSeconds;
+    newInstance.delayBeforeNextRunFactor = instance.delayBeforeNextRunFactor;
+    newInstance.maxDurationBeforeTtlExpireInSeconds = instance.maxDurationBeforeTtlExpireInSeconds;
+    return newInstance;
   }
 
   public String getRetryDelayInSeconds() {

--- a/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
@@ -107,8 +107,6 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     this.maxDurationBeforeTtlExpireInSeconds = maxDurationBeforeTtlExpireInSeconds;
   }
 
-  public HashicorpVaultDbCredentialsConfig() {}
-
   public String getUrl() {
     return this.url;
   }

--- a/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
@@ -140,6 +140,7 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     config.setProperty("dbSecretEngineName", this.getDbSecretEngineName());
     config.setProperty("vaultDbRole", this.getVaultDbRole());
     config.setProperty("credentialType", this.getCredentialType());
+    config.setProperty("namespace", this.getNamespace());
 
     Optional.ofNullable(this.getTlsKeyStorePath())
         .map(Objects::toString)

--- a/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/HashicorpVaultDbCredentialsConfig.java
@@ -39,21 +39,66 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
   @XmlJavaTypeAdapter(PathAdapter.class)
   private Path tlsTrustStorePath;
 
-  public HashicorpVaultDbCredentialsConfig(
-      String url,
-      String namespace,
-      String approlePath,
-      String dbSecretEngineName,
-      String vaultDbRole,
-      Path tlsKeyStorePath,
-      Path tlsTrustStorePath) {
-    this.url = url;
-    this.namespace = namespace;
-    this.approlePath = approlePath;
-    this.dbSecretEngineName = dbSecretEngineName;
-    this.vaultDbRole = vaultDbRole;
-    this.tlsKeyStorePath = tlsKeyStorePath;
-    this.tlsTrustStorePath = tlsTrustStorePath;
+  @Valid @XmlElement private String retryDelayInSeconds;
+  @Valid @XmlElement private String maxRetryDelayInSeconds;
+  @Valid @XmlElement private String minDelayBeforeNextRunInSeconds;
+  @Valid @XmlElement private String delayBeforeNextRunFactor;
+  @Valid @XmlElement private String maxDurationBeforeTtlExpireInSeconds;
+
+  public HashicorpVaultDbCredentialsConfig(HashicorpVaultDbCredentialsConfig config) {
+    this.url = config.url;
+    this.namespace = config.namespace;
+    this.approlePath = config.approlePath;
+    this.dbSecretEngineName = config.dbSecretEngineName;
+    this.vaultDbRole = config.vaultDbRole;
+    this.credentialType = config.credentialType;
+    this.tlsKeyStorePath = config.tlsKeyStorePath;
+    this.tlsTrustStorePath = config.tlsTrustStorePath;
+    this.retryDelayInSeconds = config.retryDelayInSeconds;
+    this.maxRetryDelayInSeconds = config.maxRetryDelayInSeconds;
+    this.minDelayBeforeNextRunInSeconds = config.minDelayBeforeNextRunInSeconds;
+    this.delayBeforeNextRunFactor = config.delayBeforeNextRunFactor;
+    this.maxDurationBeforeTtlExpireInSeconds = config.maxDurationBeforeTtlExpireInSeconds;
+  }
+
+  public String getRetryDelayInSeconds() {
+    return retryDelayInSeconds;
+  }
+
+  void setRetryDelayInSeconds(String retryDelayInSeconds) {
+    this.retryDelayInSeconds = retryDelayInSeconds;
+  }
+
+  public String getMaxRetryDelayInSeconds() {
+    return maxRetryDelayInSeconds;
+  }
+
+  void setMaxRetryDelayInSeconds(String maxRetryDelayInSeconds) {
+    this.maxRetryDelayInSeconds = maxRetryDelayInSeconds;
+  }
+
+  public String getMinDelayBeforeNextRunInSeconds() {
+    return minDelayBeforeNextRunInSeconds;
+  }
+
+  void setMinDelayBeforeNextRunInSeconds(String minDelayBeforeNextRunInSeconds) {
+    this.minDelayBeforeNextRunInSeconds = minDelayBeforeNextRunInSeconds;
+  }
+
+  public String getDelayBeforeNextRunFactor() {
+    return delayBeforeNextRunFactor;
+  }
+
+  void setDelayBeforeNextRunFactor(String delayBeforeNextRunFactor) {
+    this.delayBeforeNextRunFactor = delayBeforeNextRunFactor;
+  }
+
+  public String getMaxDurationBeforeTtlExpireInSeconds() {
+    return maxDurationBeforeTtlExpireInSeconds;
+  }
+
+  void setMaxDurationBeforeTtlExpireInSeconds(String maxDurationBeforeTtlExpireInSeconds) {
+    this.maxDurationBeforeTtlExpireInSeconds = maxDurationBeforeTtlExpireInSeconds;
   }
 
   public HashicorpVaultDbCredentialsConfig() {}
@@ -62,7 +107,7 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     return this.url;
   }
 
-  public void setUrl(String url) {
+  void setUrl(String url) {
     this.url = url;
   }
 
@@ -70,7 +115,7 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     return namespace;
   }
 
-  public void setNamespace(String namespace) {
+  void setNamespace(String namespace) {
     this.namespace = namespace;
   }
 
@@ -81,7 +126,7 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     return dbSecretEngineName;
   }
 
-  public void setDbSecretEngineName(String dbSecretEngineName) {
+  void setDbSecretEngineName(String dbSecretEngineName) {
     this.dbSecretEngineName = dbSecretEngineName;
   }
 
@@ -89,7 +134,7 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     return vaultDbRole;
   }
 
-  public void setVaultDbRole(String vaultDbRole) {
+  void setVaultDbRole(String vaultDbRole) {
     this.vaultDbRole = vaultDbRole;
   }
 
@@ -97,7 +142,7 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     return tlsKeyStorePath;
   }
 
-  public void setTlsKeyStorePath(Path tlsKeyStorePath) {
+  void setTlsKeyStorePath(Path tlsKeyStorePath) {
     this.tlsKeyStorePath = tlsKeyStorePath;
   }
 
@@ -105,7 +150,7 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     return tlsTrustStorePath;
   }
 
-  public void setTlsTrustStorePath(Path tlsTrustStorePath) {
+  void setTlsTrustStorePath(Path tlsTrustStorePath) {
     this.tlsTrustStorePath = tlsTrustStorePath;
   }
 
@@ -116,7 +161,7 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     return approlePath;
   }
 
-  public void setApprolePath(String approlePath) {
+  void setApprolePath(String approlePath) {
     this.approlePath = approlePath;
   }
 
@@ -128,7 +173,7 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     return credentialType;
   }
 
-  public void setCredentialType(String credentialType) {
+  void setCredentialType(String credentialType) {
     this.credentialType = credentialType;
   }
 
@@ -141,6 +186,12 @@ public class HashicorpVaultDbCredentialsConfig extends ConfigItem {
     config.setProperty("vaultDbRole", this.getVaultDbRole());
     config.setProperty("credentialType", this.getCredentialType());
     config.setProperty("namespace", this.getNamespace());
+    config.setProperty("retryDelayInSeconds", this.getRetryDelayInSeconds());
+    config.setProperty("maxRetryDelayInSeconds", this.getMaxRetryDelayInSeconds());
+    config.setProperty("minDelayBeforeNextRunInSeconds", this.getMinDelayBeforeNextRunInSeconds());
+    config.setProperty("delayBeforeNextRunFactor", this.getDelayBeforeNextRunFactor());
+    config.setProperty(
+        "maxDurationBeforeTtlExpireInSeconds", this.getMaxDurationBeforeTtlExpireInSeconds());
 
     Optional.ofNullable(this.getTlsKeyStorePath())
         .map(Objects::toString)

--- a/config/src/main/java/com/quorum/tessera/config/JdbcConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/JdbcConfig.java
@@ -22,8 +22,14 @@ public class JdbcConfig extends ConfigItem {
 
   @XmlElement private int fetchSize;
 
-  public JdbcConfig(String username, String password, String url) {
-    this.username = username;
+  @XmlElement
+  private HashicorpVaultDbCredentialsConfig hashicorpVaultDbCredentialsConfig;
+
+  public JdbcConfig(
+      String username,
+      String password,
+      String url) {
+        this.username = username;
     this.password = password;
     this.url = url;
   }
@@ -62,6 +68,15 @@ public class JdbcConfig extends ConfigItem {
 
   public void setAutoCreateTables(boolean autoCreateTables) {
     this.autoCreateTables = autoCreateTables;
+  }
+
+  public HashicorpVaultDbCredentialsConfig getHashicorpVaultDbCredentialsConfig() {
+    return hashicorpVaultDbCredentialsConfig;
+  }
+
+  public void setHashicorpVaultDbCredentialsConfig(
+    HashicorpVaultDbCredentialsConfig hashicorpVaultDbCredentialsConfig) {
+    this.hashicorpVaultDbCredentialsConfig = hashicorpVaultDbCredentialsConfig;
   }
 
   public int getFetchSize() {

--- a/config/src/main/java/com/quorum/tessera/config/JdbcConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/JdbcConfig.java
@@ -22,14 +22,10 @@ public class JdbcConfig extends ConfigItem {
 
   @XmlElement private int fetchSize;
 
-  @XmlElement
-  private HashicorpVaultDbCredentialsConfig hashicorpVaultDbCredentialsConfig;
+  @XmlElement private HashicorpVaultDbCredentialsConfig hashicorpVaultDbCredentialsConfig;
 
-  public JdbcConfig(
-      String username,
-      String password,
-      String url) {
-        this.username = username;
+  public JdbcConfig(String username, String password, String url) {
+    this.username = username;
     this.password = password;
     this.url = url;
   }
@@ -75,7 +71,7 @@ public class JdbcConfig extends ConfigItem {
   }
 
   public void setHashicorpVaultDbCredentialsConfig(
-    HashicorpVaultDbCredentialsConfig hashicorpVaultDbCredentialsConfig) {
+      HashicorpVaultDbCredentialsConfig hashicorpVaultDbCredentialsConfig) {
     this.hashicorpVaultDbCredentialsConfig = hashicorpVaultDbCredentialsConfig;
   }
 

--- a/config/src/main/java/com/quorum/tessera/config/JdbcConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/JdbcConfig.java
@@ -67,7 +67,7 @@ public class JdbcConfig extends ConfigItem {
   }
 
   public HashicorpVaultDbCredentialsConfig getHashicorpVaultDbCredentialsConfig() {
-    return new HashicorpVaultDbCredentialsConfig(hashicorpVaultDbCredentialsConfig);
+    return HashicorpVaultDbCredentialsConfig.clone(this.hashicorpVaultDbCredentialsConfig);
   }
 
   void setHashicorpVaultDbCredentialsConfig(

--- a/config/src/main/java/com/quorum/tessera/config/JdbcConfig.java
+++ b/config/src/main/java/com/quorum/tessera/config/JdbcConfig.java
@@ -67,10 +67,10 @@ public class JdbcConfig extends ConfigItem {
   }
 
   public HashicorpVaultDbCredentialsConfig getHashicorpVaultDbCredentialsConfig() {
-    return hashicorpVaultDbCredentialsConfig;
+    return new HashicorpVaultDbCredentialsConfig(hashicorpVaultDbCredentialsConfig);
   }
 
-  public void setHashicorpVaultDbCredentialsConfig(
+  void setHashicorpVaultDbCredentialsConfig(
       HashicorpVaultDbCredentialsConfig hashicorpVaultDbCredentialsConfig) {
     this.hashicorpVaultDbCredentialsConfig = hashicorpVaultDbCredentialsConfig;
   }

--- a/config/src/main/java/com/quorum/tessera/config/util/JaxbUtil.java
+++ b/config/src/main/java/com/quorum/tessera/config/util/JaxbUtil.java
@@ -39,7 +39,8 @@ public final class JaxbUtil {
         SslConfig.class,
         SslTrustMode.class,
         ConfigProperties.class,
-        DefaultKeyVaultConfig.class
+        DefaultKeyVaultConfig.class,
+        HashicorpVaultDbCredentialsConfig.class
       };
 
   private JaxbUtil() {}

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultException.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultException.java
@@ -1,0 +1,15 @@
+package com.quorum.tessera.key.vault.hashicorp;
+
+public class HashicorpDbCredentialsVaultException extends RuntimeException {
+  HashicorpDbCredentialsVaultException(Throwable cause) {
+    super(cause);
+  }
+
+  HashicorpDbCredentialsVaultException(String message) {
+    super(message);
+  }
+
+  HashicorpDbCredentialsVaultException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultException.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultException.java
@@ -1,9 +1,6 @@
 package com.quorum.tessera.key.vault.hashicorp;
 
 public class HashicorpDbCredentialsVaultException extends RuntimeException {
-  HashicorpDbCredentialsVaultException(Throwable cause) {
-    super(cause);
-  }
 
   HashicorpDbCredentialsVaultException(String message) {
     super(message);

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultService.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultService.java
@@ -4,9 +4,10 @@ import com.quorum.tessera.config.ConfigException;
 import com.quorum.tessera.config.KeyVaultConfig;
 import com.quorum.tessera.key.vault.DbCredentials;
 import com.quorum.tessera.key.vault.DbCredentialsVaultService;
-import java.util.Map;
 import org.springframework.vault.core.VaultOperations;
 import org.springframework.vault.support.VaultResponse;
+
+import java.util.Map;
 
 public class HashicorpDbCredentialsVaultService implements DbCredentialsVaultService {
 
@@ -21,12 +22,6 @@ public class HashicorpDbCredentialsVaultService implements DbCredentialsVaultSer
 
   HashicorpDbCredentialsVaultService(
       VaultOperations vaultOperations, KeyVaultConfig keyVaultConfig) {
-
-    if (!keyVaultConfig.hasProperty("vaultDbRole")
-        || keyVaultConfig.getProperty("vaultDbRole").isEmpty()) {
-      throw new HashicorpVaultException(
-          "[vaultDbRole] missing in the configuration. [vaultDbRole] should be defined in configuration property: jdbc.hashicorpVaultDbCredentialsConfig");
-    }
 
     this.vaultOperations = vaultOperations;
     this.keyVaultConfig = keyVaultConfig;

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultService.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultService.java
@@ -4,10 +4,9 @@ import com.quorum.tessera.config.ConfigException;
 import com.quorum.tessera.config.KeyVaultConfig;
 import com.quorum.tessera.key.vault.DbCredentials;
 import com.quorum.tessera.key.vault.DbCredentialsVaultService;
+import java.util.Map;
 import org.springframework.vault.core.VaultOperations;
 import org.springframework.vault.support.VaultResponse;
-
-import java.util.Map;
 
 public class HashicorpDbCredentialsVaultService implements DbCredentialsVaultService {
 
@@ -53,8 +52,8 @@ public class HashicorpDbCredentialsVaultService implements DbCredentialsVaultSer
           vaultOperations.read(
               String.format("%s/%s/%s", dbSecretEngineName, credentialPath, vaultDbRole));
     } catch (Exception ex) {
-      throw new RuntimeException(
-          "Unexpected error reading db credentials from hashicorp vault", ex);
+      throw new ConfigException(
+          new RuntimeException("Unexpected error reading db credentials from hashicorp vault", ex));
     }
 
     if (response != null) {

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultService.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultService.java
@@ -19,27 +19,32 @@ public class HashicorpDbCredentialsVaultService implements DbCredentialsVaultSer
 
   private String credentialPath = "static-creds";
 
-  HashicorpDbCredentialsVaultService(VaultOperations vaultOperations, KeyVaultConfig keyVaultConfig) {
+  HashicorpDbCredentialsVaultService(
+      VaultOperations vaultOperations, KeyVaultConfig keyVaultConfig) {
 
-    if (!keyVaultConfig.hasProperty("vaultDbRole") || keyVaultConfig.getProperty("vaultDbRole").isEmpty()){
-      throw new HashicorpVaultException("[vaultDbRole] missing in the configuration. [vaultDbRole] should be defined in configuration property: jdbc.hashicorpVaultDbCredentialsConfig");
+    if (!keyVaultConfig.hasProperty("vaultDbRole")
+        || keyVaultConfig.getProperty("vaultDbRole").isEmpty()) {
+      throw new HashicorpVaultException(
+          "[vaultDbRole] missing in the configuration. [vaultDbRole] should be defined in configuration property: jdbc.hashicorpVaultDbCredentialsConfig");
     }
 
     this.vaultOperations = vaultOperations;
     this.keyVaultConfig = keyVaultConfig;
     this.vaultDbRole = keyVaultConfig.getProperty("vaultDbRole").get();
 
-    if (keyVaultConfig.hasProperty("dbSecretEngineName") && keyVaultConfig.getProperty("dbSecretEngineName").isPresent()){
+    if (keyVaultConfig.hasProperty("dbSecretEngineName")
+        && keyVaultConfig.getProperty("dbSecretEngineName").isPresent()) {
       this.dbSecretEngineName = keyVaultConfig.getProperty("dbSecretEngineName").get();
     }
 
-    if (keyVaultConfig.hasProperty("credentialType") && keyVaultConfig.getProperty("credentialType").isPresent()){
+    if (keyVaultConfig.hasProperty("credentialType")
+        && keyVaultConfig.getProperty("credentialType").isPresent()) {
       this.credentialType = keyVaultConfig.getProperty("credentialType").get();
     }
 
-    if ("dynamic".equals(this.credentialType)){
+    if ("dynamic".equals(this.credentialType)) {
       this.credentialPath = "creds";
-    }else{
+    } else {
       this.credentialPath = "static-creds";
     }
   }

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultService.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultService.java
@@ -1,0 +1,108 @@
+package com.quorum.tessera.key.vault.hashicorp;
+
+import com.quorum.tessera.config.ConfigException;
+import com.quorum.tessera.config.KeyVaultConfig;
+import com.quorum.tessera.key.vault.DbCredentials;
+import com.quorum.tessera.key.vault.DbCredentialsVaultService;
+import java.util.Map;
+import org.springframework.vault.core.VaultOperations;
+import org.springframework.vault.support.VaultResponse;
+
+public class HashicorpDbCredentialsVaultService implements DbCredentialsVaultService {
+
+  private final VaultOperations vaultOperations;
+  private final KeyVaultConfig keyVaultConfig;
+
+  private String dbSecretEngineName = "database";
+  private String vaultDbRole;
+  private String credentialType = "static";
+
+  private String credentialPath = "static-creds";
+
+  HashicorpDbCredentialsVaultService(VaultOperations vaultOperations, KeyVaultConfig keyVaultConfig) {
+
+    if (!keyVaultConfig.hasProperty("vaultDbRole") || keyVaultConfig.getProperty("vaultDbRole").isEmpty()){
+      throw new HashicorpVaultException("[vaultDbRole] missing in the configuration. [vaultDbRole] should be defined in configuration property: jdbc.hashicorpVaultDbCredentialsConfig");
+    }
+
+    this.vaultOperations = vaultOperations;
+    this.keyVaultConfig = keyVaultConfig;
+    this.vaultDbRole = keyVaultConfig.getProperty("vaultDbRole").get();
+
+    if (keyVaultConfig.hasProperty("dbSecretEngineName") && keyVaultConfig.getProperty("dbSecretEngineName").isPresent()){
+      this.dbSecretEngineName = keyVaultConfig.getProperty("dbSecretEngineName").get();
+    }
+
+    if (keyVaultConfig.hasProperty("credentialType") && keyVaultConfig.getProperty("credentialType").isPresent()){
+      this.credentialType = keyVaultConfig.getProperty("credentialType").get();
+    }
+
+    if ("dynamic".equals(this.credentialType)){
+      this.credentialPath = "creds";
+    }else{
+      this.credentialPath = "static-creds";
+    }
+  }
+
+  public HashicorpDbCredentials getDbCredentials() {
+    var credentials = new HashicorpDbCredentials();
+    VaultResponse response;
+    try {
+
+      response =
+          vaultOperations.read(
+              String.format("%s/%s/%s", dbSecretEngineName, credentialPath, vaultDbRole));
+    } catch (Exception ex) {
+      throw new RuntimeException(
+          "Unexpected error reading db credentials from hashicorp vault", ex);
+    }
+
+    if (response != null) {
+      if (response.getData() != null) {
+        Map<String, Object> data = response.getData();
+        credentials.setUsername(data.get("username").toString());
+        credentials.setPassword(data.get("password").toString());
+        credentials.setLeaseDurationInSec(
+            response.getData().containsKey("ttl")
+                ? Long.valueOf((Integer) response.getData().get("ttl"))
+                : response.getLeaseDuration());
+      }
+    } else {
+      throw new ConfigException(
+          new RuntimeException(
+              "Empty response from Hashicorp vault while trying to retrieve database credentials."));
+    }
+    return credentials;
+  }
+
+  public static class HashicorpDbCredentials implements DbCredentials {
+
+    private String username;
+    private String password;
+    private long leaseDurationInSec;
+
+    void setUsername(String username) {
+      this.username = username;
+    }
+
+    void setPassword(String password) {
+      this.password = password;
+    }
+
+    void setLeaseDurationInSec(long leaseDurationInSec) {
+      this.leaseDurationInSec = leaseDurationInSec;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public long getLeaseDurationInSec() {
+      return leaseDurationInSec;
+    }
+  }
+}

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultService.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultService.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.key.vault.hashicorp;
 
-import com.quorum.tessera.config.ConfigException;
 import com.quorum.tessera.config.KeyVaultConfig;
 import com.quorum.tessera.key.vault.DbCredentials;
 import com.quorum.tessera.key.vault.DbCredentialsVaultService;
@@ -11,7 +10,6 @@ import org.springframework.vault.support.VaultResponse;
 public class HashicorpDbCredentialsVaultService implements DbCredentialsVaultService {
 
   private final VaultOperations vaultOperations;
-  private final KeyVaultConfig keyVaultConfig;
 
   private String dbSecretEngineName = "database";
   private String vaultDbRole;
@@ -23,7 +21,6 @@ public class HashicorpDbCredentialsVaultService implements DbCredentialsVaultSer
       VaultOperations vaultOperations, KeyVaultConfig keyVaultConfig) {
 
     this.vaultOperations = vaultOperations;
-    this.keyVaultConfig = keyVaultConfig;
     this.vaultDbRole = keyVaultConfig.getProperty("vaultDbRole").get();
 
     if (keyVaultConfig.hasProperty("dbSecretEngineName")
@@ -52,8 +49,8 @@ public class HashicorpDbCredentialsVaultService implements DbCredentialsVaultSer
           vaultOperations.read(
               String.format("%s/%s/%s", dbSecretEngineName, credentialPath, vaultDbRole));
     } catch (Exception ex) {
-      throw new ConfigException(
-          new RuntimeException("Unexpected error reading db credentials from hashicorp vault", ex));
+      throw new HashicorpDbCredentialsVaultException(
+          "Unexpected error reading db credentials from hashicorp vault", ex);
     }
 
     if (response != null) {
@@ -67,9 +64,8 @@ public class HashicorpDbCredentialsVaultService implements DbCredentialsVaultSer
                 : response.getLeaseDuration());
       }
     } else {
-      throw new ConfigException(
-          new RuntimeException(
-              "Empty response from Hashicorp vault while trying to retrieve database credentials."));
+      throw new HashicorpDbCredentialsVaultException(
+          "Empty response from Hashicorp vault while trying to retrieve database credentials.");
     }
     return credentials;
   }

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
@@ -1,33 +1,13 @@
 package com.quorum.tessera.key.vault.hashicorp;
 
-import static com.quorum.tessera.config.util.EnvironmentVariables.*;
-import static com.quorum.tessera.config.util.EnvironmentVariables.HASHICORP_SECRET_ID;
-import static com.quorum.tessera.key.vault.hashicorp.HashicorpKeyVaultServiceFactoryUtil.NAMESPACE_KEY;
-
-import com.quorum.tessera.config.*;
+import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.KeyVaultType;
 import com.quorum.tessera.config.util.EnvironmentVariableProvider;
 import com.quorum.tessera.key.vault.DbCredentialsVaultServiceFactory;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.NoSuchElementException;
+
 import java.util.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.client.ClientHttpRequestFactory;
-import org.springframework.vault.authentication.ClientAuthentication;
-import org.springframework.vault.authentication.SessionManager;
-import org.springframework.vault.authentication.SimpleSessionManager;
-import org.springframework.vault.client.RestTemplateBuilder;
-import org.springframework.vault.client.VaultEndpoint;
-import org.springframework.vault.core.VaultOperations;
-import org.springframework.vault.core.VaultTemplate;
-import org.springframework.vault.support.ClientOptions;
-import org.springframework.vault.support.SslConfiguration;
 
-public class HashicorpDbCredentialsVaultServiceFactory implements DbCredentialsVaultServiceFactory {
-
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(HashicorpDbCredentialsVaultServiceFactory.class);
+public class HashicorpDbCredentialsVaultServiceFactory extends HashicorpVaultServiceFactory implements DbCredentialsVaultServiceFactory {
 
   public HashicorpDbCredentialsVaultService create(
       Config config, EnvironmentVariableProvider envProvider) {
@@ -39,105 +19,22 @@ public class HashicorpDbCredentialsVaultServiceFactory implements DbCredentialsV
     return this.create(config, envProvider, util);
   }
 
-  // This method should not be called directly. It has been left package-private to enable injection
-  // of util during
-  // testing
   HashicorpDbCredentialsVaultService create(
       Config config,
       EnvironmentVariableProvider envProvider,
       HashicorpKeyVaultServiceFactoryUtil util) {
-    Objects.requireNonNull(config);
-    Objects.requireNonNull(envProvider);
-    Objects.requireNonNull(util);
 
-    final String roleId = envProvider.getEnv(HASHICORP_ROLE_ID);
-    final String secretId = envProvider.getEnv(HASHICORP_SECRET_ID);
-    final String authToken = envProvider.getEnv(HASHICORP_TOKEN);
-
-    if (roleId == null && secretId == null && authToken == null) {
-      throw new HashicorpCredentialNotSetException(
-          "Environment variables must be set to authenticate with Hashicorp Vault.  Set the "
-              + HASHICORP_ROLE_ID
-              + " and "
-              + HASHICORP_SECRET_ID
-              + " environment variables if using the AppRole authentication method.  Set the "
-              + HASHICORP_TOKEN
-              + " environment variable if using another authentication method.");
-    } else if (isOnlyOneInputNull(roleId, secretId)) {
-      throw new HashicorpCredentialNotSetException(
-          "Only one of the "
-              + HASHICORP_ROLE_ID
-              + " and "
-              + HASHICORP_SECRET_ID
-              + " environment variables to authenticate with Hashicorp Vault using the AppRole method has been set");
-    }
-
-    KeyVaultConfig keyVaultConfig =
-        config.getJdbcConfig().getHashicorpVaultDbCredentialsConfig().toKeyVaultConfig();
-    VaultEndpoint vaultEndpoint;
-
-    try {
-      URI uri = new URI(keyVaultConfig.getProperty("url").get());
-      LOGGER.info("URL for Hashicorp key vault is {}", keyVaultConfig.getProperty("url").get());
-      vaultEndpoint = VaultEndpoint.from(uri);
-    } catch (URISyntaxException | NoSuchElementException | IllegalArgumentException e) {
-      throw new ConfigException(
-          new RuntimeException("Provided Hashicorp Vault url is incorrectly formatted", e));
-    }
-
-    SslConfiguration sslConfiguration = util.configureSsl(keyVaultConfig, envProvider);
-
-    ClientOptions clientOptions = new ClientOptions();
-
-    ClientHttpRequestFactory clientHttpRequestFactory =
-        util.createClientHttpRequestFactory(clientOptions, sslConfiguration);
-
-    ClientAuthentication clientAuthentication =
-        util.configureClientAuthentication(
-            keyVaultConfig, envProvider, clientHttpRequestFactory, vaultEndpoint);
-
-    SessionManager sessionManager = new SimpleSessionManager(clientAuthentication);
-
-    VaultOperations vaultOperations =
-        getVaultOperations(
-            keyVaultConfig, vaultEndpoint, clientHttpRequestFactory, sessionManager, util);
-
-    return new HashicorpDbCredentialsVaultService(vaultOperations, keyVaultConfig);
-  }
-
-  private VaultOperations getVaultOperations(
-      KeyVaultConfig keyVaultConfig,
-      VaultEndpoint vaultEndpoint,
-      ClientHttpRequestFactory clientHttpRequestFactory,
-      SessionManager sessionManager,
-      HashicorpKeyVaultServiceFactoryUtil util) {
-
-    VaultOperations vaultOperations;
-
-    if (keyVaultConfig.hasProperty(NAMESPACE_KEY)
-        && keyVaultConfig.getProperty(NAMESPACE_KEY).isPresent()) {
-      LOGGER.info(
-          "Namespace for Hashicorp key vault is {}",
-          keyVaultConfig.getProperty(NAMESPACE_KEY).get());
-
-      String namespace = keyVaultConfig.getProperty(NAMESPACE_KEY).get();
-      RestTemplateBuilder restTemplateBuilder =
-          util.getRestTemplateWithVaultNamespace(
-              namespace, clientHttpRequestFactory, vaultEndpoint);
-
-      vaultOperations = new VaultTemplate(restTemplateBuilder, sessionManager);
-    } else {
-      vaultOperations = new VaultTemplate(vaultEndpoint, clientHttpRequestFactory, sessionManager);
-    }
-
-    return vaultOperations;
+    return super.create(config, envProvider, util,
+      (appConfig)->{
+        return appConfig.getJdbcConfig()
+          .getHashicorpVaultDbCredentialsConfig()
+          .toKeyVaultConfig();
+      },
+      HashicorpDbCredentialsVaultService::new
+    );
   }
 
   public KeyVaultType getType() {
     return KeyVaultType.HASHICORP;
-  }
-
-  private boolean isOnlyOneInputNull(Object obj1, Object obj2) {
-    return Objects.isNull(obj1) ^ Objects.isNull(obj2);
   }
 }

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
@@ -1,15 +1,16 @@
 package com.quorum.tessera.key.vault.hashicorp;
 
 import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.ConfigException;
 import com.quorum.tessera.config.KeyVaultConfig;
 import com.quorum.tessera.config.KeyVaultType;
 import com.quorum.tessera.config.util.EnvironmentVariableProvider;
 import com.quorum.tessera.key.vault.DbCredentialsVaultServiceFactory;
-
 import java.util.List;
 import java.util.Objects;
 
-public class HashicorpDbCredentialsVaultServiceFactory extends HashicorpVaultServiceFactory implements DbCredentialsVaultServiceFactory {
+public class HashicorpDbCredentialsVaultServiceFactory extends HashicorpVaultServiceFactory
+    implements DbCredentialsVaultServiceFactory {
 
   public HashicorpDbCredentialsVaultService create(
       Config config, EnvironmentVariableProvider envProvider) {
@@ -26,28 +27,36 @@ public class HashicorpDbCredentialsVaultServiceFactory extends HashicorpVaultSer
       EnvironmentVariableProvider envProvider,
       HashicorpKeyVaultServiceFactoryUtil util) {
 
-    return super.create(config, envProvider, util,
-      (appConfig)->{
-        var keyVaultConfig = appConfig.getJdbcConfig()
-          .getHashicorpVaultDbCredentialsConfig()
-          .toKeyVaultConfig();
-        validateRequiredConfigurationPropertiesArePresent(keyVaultConfig);
-        return keyVaultConfig;
-      },
-      HashicorpDbCredentialsVaultService::new
-    );
+    return super.create(
+        config,
+        envProvider,
+        util,
+        this::getKeyVaultConfig,
+        HashicorpDbCredentialsVaultService::new);
   }
 
-  void validateRequiredConfigurationPropertiesArePresent(KeyVaultConfig keyVaultConfig){
-    var requiredProperties = List.of("url","dbSecretEngineName","vaultDbRole","approlePath");
-    var missingProperties = requiredProperties.stream().filter(
-      propName->
-        !keyVaultConfig.hasProperty(propName) || keyVaultConfig.getProperty(propName).isEmpty()
-    ).toList();
-    if (!missingProperties.isEmpty()){
-      throw new HashicorpVaultException(
-        String.format("[%s] missing in the configuration. This/these properties should be defined in configuration section: jdbc.hashicorpVaultDbCredentialsConfig", String.join(", ", missingProperties))
-      );
+  private KeyVaultConfig getKeyVaultConfig(Config config) {
+    var keyVaultConfig =
+        config.getJdbcConfig().getHashicorpVaultDbCredentialsConfig().toKeyVaultConfig();
+    validateRequiredConfigurationPropertiesArePresent(keyVaultConfig);
+    return keyVaultConfig;
+  }
+
+  void validateRequiredConfigurationPropertiesArePresent(KeyVaultConfig keyVaultConfig) {
+    var requiredProperties = List.of("url", "dbSecretEngineName", "vaultDbRole", "approlePath");
+    var missingProperties =
+        requiredProperties.stream()
+            .filter(
+                propName ->
+                    !keyVaultConfig.hasProperty(propName)
+                        || keyVaultConfig.getProperty(propName).isEmpty())
+            .toList();
+    if (!missingProperties.isEmpty()) {
+      throw new ConfigException(
+          new RuntimeException(
+              String.format(
+                  "[%s] missing in the configuration. This/these properties should be defined in configuration section: jdbc.hashicorpVaultDbCredentialsConfig",
+                  String.join(", ", missingProperties))));
     }
   }
 

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
@@ -11,7 +11,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.client.ClientHttpRequestFactory;
@@ -73,7 +72,8 @@ public class HashicorpDbCredentialsVaultServiceFactory implements DbCredentialsV
               + " environment variables to authenticate with Hashicorp Vault using the AppRole method has been set");
     }
 
-    KeyVaultConfig keyVaultConfig = config.getJdbcConfig().getHashicorpVaultDbCredentialsConfig().toKeyVaultConfig();
+    KeyVaultConfig keyVaultConfig =
+        config.getJdbcConfig().getHashicorpVaultDbCredentialsConfig().toKeyVaultConfig();
     VaultEndpoint vaultEndpoint;
 
     try {

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
@@ -53,7 +53,7 @@ public class HashicorpDbCredentialsVaultServiceFactory extends HashicorpVaultSer
             .toList();
     if (!missingProperties.isEmpty()) {
       throw new ConfigException(
-          new RuntimeException(
+          new HashicorpVaultException(
               String.format(
                   "[%s] missing in the configuration. This/these properties should be defined in configuration section: jdbc.hashicorpVaultDbCredentialsConfig",
                   String.join(", ", missingProperties))));

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
@@ -1,10 +1,12 @@
 package com.quorum.tessera.key.vault.hashicorp;
 
 import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.KeyVaultConfig;
 import com.quorum.tessera.config.KeyVaultType;
 import com.quorum.tessera.config.util.EnvironmentVariableProvider;
 import com.quorum.tessera.key.vault.DbCredentialsVaultServiceFactory;
 
+import java.util.List;
 import java.util.Objects;
 
 public class HashicorpDbCredentialsVaultServiceFactory extends HashicorpVaultServiceFactory implements DbCredentialsVaultServiceFactory {
@@ -26,12 +28,27 @@ public class HashicorpDbCredentialsVaultServiceFactory extends HashicorpVaultSer
 
     return super.create(config, envProvider, util,
       (appConfig)->{
-        return appConfig.getJdbcConfig()
+        var keyVaultConfig = appConfig.getJdbcConfig()
           .getHashicorpVaultDbCredentialsConfig()
           .toKeyVaultConfig();
+        validateRequiredConfigurationPropertiesArePresent(keyVaultConfig);
+        return keyVaultConfig;
       },
       HashicorpDbCredentialsVaultService::new
     );
+  }
+
+  void validateRequiredConfigurationPropertiesArePresent(KeyVaultConfig keyVaultConfig){
+    var requiredProperties = List.of("url","dbSecretEngineName","vaultDbRole","approlePath");
+    var missingProperties = requiredProperties.stream().filter(
+      propName->
+        !keyVaultConfig.hasProperty(propName) || keyVaultConfig.getProperty(propName).isEmpty()
+    ).toList();
+    if (!missingProperties.isEmpty()){
+      throw new HashicorpVaultException(
+        String.format("[%s] missing in the configuration. This/these properties should be defined in configuration section: jdbc.hashicorpVaultDbCredentialsConfig", String.join(", ", missingProperties))
+      );
+    }
   }
 
   public KeyVaultType getType() {

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
@@ -1,0 +1,143 @@
+package com.quorum.tessera.key.vault.hashicorp;
+
+import static com.quorum.tessera.config.util.EnvironmentVariables.*;
+import static com.quorum.tessera.config.util.EnvironmentVariables.HASHICORP_SECRET_ID;
+import static com.quorum.tessera.key.vault.hashicorp.HashicorpKeyVaultServiceFactoryUtil.NAMESPACE_KEY;
+
+import com.quorum.tessera.config.*;
+import com.quorum.tessera.config.util.EnvironmentVariableProvider;
+import com.quorum.tessera.key.vault.DbCredentialsVaultServiceFactory;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.vault.authentication.ClientAuthentication;
+import org.springframework.vault.authentication.SessionManager;
+import org.springframework.vault.authentication.SimpleSessionManager;
+import org.springframework.vault.client.RestTemplateBuilder;
+import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.core.VaultOperations;
+import org.springframework.vault.core.VaultTemplate;
+import org.springframework.vault.support.ClientOptions;
+import org.springframework.vault.support.SslConfiguration;
+
+public class HashicorpDbCredentialsVaultServiceFactory implements DbCredentialsVaultServiceFactory {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(HashicorpDbCredentialsVaultServiceFactory.class);
+
+  public HashicorpDbCredentialsVaultService create(
+      Config config, EnvironmentVariableProvider envProvider) {
+    Objects.requireNonNull(config);
+    Objects.requireNonNull(envProvider);
+
+    HashicorpKeyVaultServiceFactoryUtil util = new HashicorpKeyVaultServiceFactoryUtil();
+
+    return this.create(config, envProvider, util);
+  }
+
+  // This method should not be called directly. It has been left package-private to enable injection
+  // of util during
+  // testing
+  HashicorpDbCredentialsVaultService create(
+      Config config,
+      EnvironmentVariableProvider envProvider,
+      HashicorpKeyVaultServiceFactoryUtil util) {
+    Objects.requireNonNull(config);
+    Objects.requireNonNull(envProvider);
+    Objects.requireNonNull(util);
+
+    final String roleId = envProvider.getEnv(HASHICORP_ROLE_ID);
+    final String secretId = envProvider.getEnv(HASHICORP_SECRET_ID);
+    final String authToken = envProvider.getEnv(HASHICORP_TOKEN);
+
+    if (roleId == null && secretId == null && authToken == null) {
+      throw new HashicorpCredentialNotSetException(
+          "Environment variables must be set to authenticate with Hashicorp Vault.  Set the "
+              + HASHICORP_ROLE_ID
+              + " and "
+              + HASHICORP_SECRET_ID
+              + " environment variables if using the AppRole authentication method.  Set the "
+              + HASHICORP_TOKEN
+              + " environment variable if using another authentication method.");
+    } else if (isOnlyOneInputNull(roleId, secretId)) {
+      throw new HashicorpCredentialNotSetException(
+          "Only one of the "
+              + HASHICORP_ROLE_ID
+              + " and "
+              + HASHICORP_SECRET_ID
+              + " environment variables to authenticate with Hashicorp Vault using the AppRole method has been set");
+    }
+
+    KeyVaultConfig keyVaultConfig = config.getJdbcConfig().getHashicorpVaultDbCredentialsConfig().toKeyVaultConfig();
+    VaultEndpoint vaultEndpoint;
+
+    try {
+      URI uri = new URI(keyVaultConfig.getProperty("url").get());
+      LOGGER.info("URL for Hashicorp key vault is {}", keyVaultConfig.getProperty("url").get());
+      vaultEndpoint = VaultEndpoint.from(uri);
+    } catch (URISyntaxException | NoSuchElementException | IllegalArgumentException e) {
+      throw new ConfigException(
+          new RuntimeException("Provided Hashicorp Vault url is incorrectly formatted", e));
+    }
+
+    SslConfiguration sslConfiguration = util.configureSsl(keyVaultConfig, envProvider);
+
+    ClientOptions clientOptions = new ClientOptions();
+
+    ClientHttpRequestFactory clientHttpRequestFactory =
+        util.createClientHttpRequestFactory(clientOptions, sslConfiguration);
+
+    ClientAuthentication clientAuthentication =
+        util.configureClientAuthentication(
+            keyVaultConfig, envProvider, clientHttpRequestFactory, vaultEndpoint);
+
+    SessionManager sessionManager = new SimpleSessionManager(clientAuthentication);
+
+    VaultOperations vaultOperations =
+        getVaultOperations(
+            keyVaultConfig, vaultEndpoint, clientHttpRequestFactory, sessionManager, util);
+
+    return new HashicorpDbCredentialsVaultService(vaultOperations, keyVaultConfig);
+  }
+
+  private VaultOperations getVaultOperations(
+      KeyVaultConfig keyVaultConfig,
+      VaultEndpoint vaultEndpoint,
+      ClientHttpRequestFactory clientHttpRequestFactory,
+      SessionManager sessionManager,
+      HashicorpKeyVaultServiceFactoryUtil util) {
+
+    VaultOperations vaultOperations;
+
+    if (keyVaultConfig.hasProperty(NAMESPACE_KEY)
+        && keyVaultConfig.getProperty(NAMESPACE_KEY).isPresent()) {
+      LOGGER.info(
+          "Namespace for Hashicorp key vault is {}",
+          keyVaultConfig.getProperty(NAMESPACE_KEY).get());
+
+      String namespace = keyVaultConfig.getProperty(NAMESPACE_KEY).get();
+      RestTemplateBuilder restTemplateBuilder =
+          util.getRestTemplateWithVaultNamespace(
+              namespace, clientHttpRequestFactory, vaultEndpoint);
+
+      vaultOperations = new VaultTemplate(restTemplateBuilder, sessionManager);
+    } else {
+      vaultOperations = new VaultTemplate(vaultEndpoint, clientHttpRequestFactory, sessionManager);
+    }
+
+    return vaultOperations;
+  }
+
+  public KeyVaultType getType() {
+    return KeyVaultType.HASHICORP;
+  }
+
+  private boolean isOnlyOneInputNull(Object obj1, Object obj2) {
+    return Objects.isNull(obj1) ^ Objects.isNull(obj2);
+  }
+}

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceFactory.java
@@ -34,7 +34,7 @@ public class HashicorpKeyVaultServiceFactory extends HashicorpVaultServiceFactor
   }
 
   private HashicorpKeyVaultService getKeyVaultService(
-      VaultOperations vaultOperations, KeyVaultConfig keyVaultConfig) {
+      VaultOperations vaultOperations, KeyVaultConfig unusedKeyVaultConfig) {
     return new HashicorpKeyVaultService(
         vaultOperations, () -> new VaultVersionedKeyValueTemplateFactory() {});
   }
@@ -45,7 +45,7 @@ public class HashicorpKeyVaultServiceFactory extends HashicorpVaultServiceFactor
         .orElseThrow(
             () ->
                 new ConfigException(
-                    new RuntimeException(
+                    new HashicorpVaultException(
                         "Trying to create Hashicorp Vault connection but no Vault configuration provided")));
   }
 

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceFactory.java
@@ -1,34 +1,14 @@
 package com.quorum.tessera.key.vault.hashicorp;
 
-import static com.quorum.tessera.config.util.EnvironmentVariables.*;
-import static com.quorum.tessera.key.vault.hashicorp.HashicorpKeyVaultServiceFactoryUtil.NAMESPACE_KEY;
-
 import com.quorum.tessera.config.*;
 import com.quorum.tessera.config.util.EnvironmentVariableProvider;
 import com.quorum.tessera.key.vault.KeyVaultService;
 import com.quorum.tessera.key.vault.KeyVaultServiceFactory;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.NoSuchElementException;
+
 import java.util.Objects;
 import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.client.ClientHttpRequestFactory;
-import org.springframework.vault.authentication.ClientAuthentication;
-import org.springframework.vault.authentication.SessionManager;
-import org.springframework.vault.authentication.SimpleSessionManager;
-import org.springframework.vault.client.RestTemplateBuilder;
-import org.springframework.vault.client.VaultEndpoint;
-import org.springframework.vault.core.VaultOperations;
-import org.springframework.vault.core.VaultTemplate;
-import org.springframework.vault.support.ClientOptions;
-import org.springframework.vault.support.SslConfiguration;
 
-public class HashicorpKeyVaultServiceFactory implements KeyVaultServiceFactory {
-
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(HashicorpKeyVaultServiceFactory.class);
+public class HashicorpKeyVaultServiceFactory extends HashicorpVaultServiceFactory implements KeyVaultServiceFactory {
 
   @Override
   public KeyVaultService create(Config config, EnvironmentVariableProvider envProvider) {
@@ -47,107 +27,27 @@ public class HashicorpKeyVaultServiceFactory implements KeyVaultServiceFactory {
       Config config,
       EnvironmentVariableProvider envProvider,
       HashicorpKeyVaultServiceFactoryUtil util) {
-    Objects.requireNonNull(config);
-    Objects.requireNonNull(envProvider);
-    Objects.requireNonNull(util);
 
-    final String roleId = envProvider.getEnv(HASHICORP_ROLE_ID);
-    final String secretId = envProvider.getEnv(HASHICORP_SECRET_ID);
-    final String authToken = envProvider.getEnv(HASHICORP_TOKEN);
-
-    if (roleId == null && secretId == null && authToken == null) {
-      throw new HashicorpCredentialNotSetException(
-          "Environment variables must be set to authenticate with Hashicorp Vault.  Set the "
-              + HASHICORP_ROLE_ID
-              + " and "
-              + HASHICORP_SECRET_ID
-              + " environment variables if using the AppRole authentication method.  Set the "
-              + HASHICORP_TOKEN
-              + " environment variable if using another authentication method.");
-    } else if (isOnlyOneInputNull(roleId, secretId)) {
-      throw new HashicorpCredentialNotSetException(
-          "Only one of the "
-              + HASHICORP_ROLE_ID
-              + " and "
-              + HASHICORP_SECRET_ID
-              + " environment variables to authenticate with Hashicorp Vault using the AppRole method has been set");
-    }
-
-    KeyVaultConfig keyVaultConfig =
-        Optional.ofNullable(config.getKeys())
+    return super.create(config, envProvider, util,
+      (appConfig)->{
+        return
+          Optional.ofNullable(appConfig.getKeys())
             .flatMap(k -> k.getKeyVaultConfig(KeyVaultType.HASHICORP))
             .orElseThrow(
-                () ->
-                    new ConfigException(
-                        new RuntimeException(
-                            "Trying to create Hashicorp Vault connection but no Vault configuration provided")));
-
-    VaultEndpoint vaultEndpoint;
-
-    try {
-      URI uri = new URI(keyVaultConfig.getProperty("url").get());
-      LOGGER.info("URL for Hashicorp key vault is {}", keyVaultConfig.getProperty("url").get());
-      vaultEndpoint = VaultEndpoint.from(uri);
-    } catch (URISyntaxException | NoSuchElementException | IllegalArgumentException e) {
-      throw new ConfigException(
-          new RuntimeException("Provided Hashicorp Vault url is incorrectly formatted", e));
-    }
-
-    SslConfiguration sslConfiguration = util.configureSsl(keyVaultConfig, envProvider);
-
-    ClientOptions clientOptions = new ClientOptions();
-
-    ClientHttpRequestFactory clientHttpRequestFactory =
-        util.createClientHttpRequestFactory(clientOptions, sslConfiguration);
-
-    ClientAuthentication clientAuthentication =
-        util.configureClientAuthentication(
-            keyVaultConfig, envProvider, clientHttpRequestFactory, vaultEndpoint);
-
-    SessionManager sessionManager = new SimpleSessionManager(clientAuthentication);
-
-    VaultOperations vaultOperations =
-        getVaultOperations(
-            keyVaultConfig, vaultEndpoint, clientHttpRequestFactory, sessionManager, util);
-
-    return new HashicorpKeyVaultService(
-        vaultOperations, () -> new VaultVersionedKeyValueTemplateFactory() {});
-  }
-
-  private VaultOperations getVaultOperations(
-      KeyVaultConfig keyVaultConfig,
-      VaultEndpoint vaultEndpoint,
-      ClientHttpRequestFactory clientHttpRequestFactory,
-      SessionManager sessionManager,
-      HashicorpKeyVaultServiceFactoryUtil util) {
-
-    VaultOperations vaultOperations;
-
-    if (keyVaultConfig.hasProperty(NAMESPACE_KEY)
-        && keyVaultConfig.getProperty(NAMESPACE_KEY).isPresent()) {
-      LOGGER.info(
-          "Namespace for Hashicorp key vault is {}",
-          keyVaultConfig.getProperty(NAMESPACE_KEY).get());
-
-      String namespace = keyVaultConfig.getProperty(NAMESPACE_KEY).get();
-      RestTemplateBuilder restTemplateBuilder =
-          util.getRestTemplateWithVaultNamespace(
-              namespace, clientHttpRequestFactory, vaultEndpoint);
-
-      vaultOperations = new VaultTemplate(restTemplateBuilder, sessionManager);
-    } else {
-      vaultOperations = new VaultTemplate(vaultEndpoint, clientHttpRequestFactory, sessionManager);
-    }
-
-    return vaultOperations;
+              () ->
+                new ConfigException(
+                  new RuntimeException(
+                    "Trying to create Hashicorp Vault connection but no Vault configuration provided")));
+      },
+      (vaultOperations, keyVaultConfig) -> {
+        return new HashicorpKeyVaultService(
+          vaultOperations, () -> new VaultVersionedKeyValueTemplateFactory() {});
+      }
+      );
   }
 
   @Override
   public KeyVaultType getType() {
     return KeyVaultType.HASHICORP;
-  }
-
-  private boolean isOnlyOneInputNull(Object obj1, Object obj2) {
-    return Objects.isNull(obj1) ^ Objects.isNull(obj2);
   }
 }

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
@@ -1,9 +1,18 @@
 package com.quorum.tessera.key.vault.hashicorp;
 
+import static com.quorum.tessera.config.util.EnvironmentVariables.*;
+import static com.quorum.tessera.key.vault.hashicorp.HashicorpKeyVaultServiceFactoryUtil.NAMESPACE_KEY;
+
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.ConfigException;
 import com.quorum.tessera.config.KeyVaultConfig;
 import com.quorum.tessera.config.util.EnvironmentVariableProvider;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.client.ClientHttpRequestFactory;
@@ -17,29 +26,17 @@ import org.springframework.vault.core.VaultTemplate;
 import org.springframework.vault.support.ClientOptions;
 import org.springframework.vault.support.SslConfiguration;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-
-import static com.quorum.tessera.config.util.EnvironmentVariables.*;
-import static com.quorum.tessera.key.vault.hashicorp.HashicorpKeyVaultServiceFactoryUtil.NAMESPACE_KEY;
-
 class HashicorpVaultServiceFactory {
 
-  private static final Logger LOGGER =
-    LoggerFactory.getLogger(HashicorpVaultServiceFactory.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(HashicorpVaultServiceFactory.class);
 
   <R> R create(
-    Config config,
-    EnvironmentVariableProvider envProvider,
-    HashicorpKeyVaultServiceFactoryUtil util,
-    Function<Config, KeyVaultConfig> keyVaultConfigProvider,
-    BiFunction<VaultOperations, KeyVaultConfig, R> keyVaultServiceProvider
+      Config config,
+      EnvironmentVariableProvider envProvider,
+      HashicorpKeyVaultServiceFactoryUtil util,
+      Function<Config, KeyVaultConfig> keyVaultConfigProvider,
+      BiFunction<VaultOperations, KeyVaultConfig, R> keyVaultServiceProvider) {
 
-    ) {
     Objects.requireNonNull(config);
     Objects.requireNonNull(envProvider);
     Objects.requireNonNull(util);
@@ -52,20 +49,20 @@ class HashicorpVaultServiceFactory {
 
     if (roleId == null && secretId == null && authToken == null) {
       throw new HashicorpCredentialNotSetException(
-        "Environment variables must be set to authenticate with Hashicorp Vault.  Set the "
-          + HASHICORP_ROLE_ID
-          + " and "
-          + HASHICORP_SECRET_ID
-          + " environment variables if using the AppRole authentication method.  Set the "
-          + HASHICORP_TOKEN
-          + " environment variable if using another authentication method.");
+          "Environment variables must be set to authenticate with Hashicorp Vault.  Set the "
+              + HASHICORP_ROLE_ID
+              + " and "
+              + HASHICORP_SECRET_ID
+              + " environment variables if using the AppRole authentication method.  Set the "
+              + HASHICORP_TOKEN
+              + " environment variable if using another authentication method.");
     } else if (isOnlyOneInputNull(roleId, secretId)) {
       throw new HashicorpCredentialNotSetException(
-        "Only one of the "
-          + HASHICORP_ROLE_ID
-          + " and "
-          + HASHICORP_SECRET_ID
-          + " environment variables to authenticate with Hashicorp Vault using the AppRole method has been set");
+          "Only one of the "
+              + HASHICORP_ROLE_ID
+              + " and "
+              + HASHICORP_SECRET_ID
+              + " environment variables to authenticate with Hashicorp Vault using the AppRole method has been set");
     }
 
     KeyVaultConfig keyVaultConfig = keyVaultConfigProvider.apply(config);
@@ -78,7 +75,7 @@ class HashicorpVaultServiceFactory {
       vaultEndpoint = VaultEndpoint.from(uri);
     } catch (URISyntaxException | NoSuchElementException | IllegalArgumentException e) {
       throw new ConfigException(
-        new RuntimeException("Provided Hashicorp Vault url is incorrectly formatted", e));
+          new RuntimeException("Provided Hashicorp Vault url is incorrectly formatted", e));
     }
 
     SslConfiguration sslConfiguration = util.configureSsl(keyVaultConfig, envProvider);
@@ -86,40 +83,40 @@ class HashicorpVaultServiceFactory {
     ClientOptions clientOptions = new ClientOptions();
 
     ClientHttpRequestFactory clientHttpRequestFactory =
-      util.createClientHttpRequestFactory(clientOptions, sslConfiguration);
+        util.createClientHttpRequestFactory(clientOptions, sslConfiguration);
 
     ClientAuthentication clientAuthentication =
-      util.configureClientAuthentication(
-        keyVaultConfig, envProvider, clientHttpRequestFactory, vaultEndpoint);
+        util.configureClientAuthentication(
+            keyVaultConfig, envProvider, clientHttpRequestFactory, vaultEndpoint);
 
     SessionManager sessionManager = new SimpleSessionManager(clientAuthentication);
 
     VaultOperations vaultOperations =
-      getVaultOperations(
-        keyVaultConfig, vaultEndpoint, clientHttpRequestFactory, sessionManager, util);
+        getVaultOperations(
+            keyVaultConfig, vaultEndpoint, clientHttpRequestFactory, sessionManager, util);
 
     return keyVaultServiceProvider.apply(vaultOperations, keyVaultConfig);
   }
 
   private VaultOperations getVaultOperations(
-    KeyVaultConfig keyVaultConfig,
-    VaultEndpoint vaultEndpoint,
-    ClientHttpRequestFactory clientHttpRequestFactory,
-    SessionManager sessionManager,
-    HashicorpKeyVaultServiceFactoryUtil util) {
+      KeyVaultConfig keyVaultConfig,
+      VaultEndpoint vaultEndpoint,
+      ClientHttpRequestFactory clientHttpRequestFactory,
+      SessionManager sessionManager,
+      HashicorpKeyVaultServiceFactoryUtil util) {
 
     VaultOperations vaultOperations;
 
     if (keyVaultConfig.hasProperty(NAMESPACE_KEY)
-      && keyVaultConfig.getProperty(NAMESPACE_KEY).isPresent()) {
+        && keyVaultConfig.getProperty(NAMESPACE_KEY).isPresent()) {
       LOGGER.info(
-        "Namespace for Hashicorp key vault is {}",
-        keyVaultConfig.getProperty(NAMESPACE_KEY).get());
+          "Namespace for Hashicorp key vault is {}",
+          keyVaultConfig.getProperty(NAMESPACE_KEY).get());
 
       String namespace = keyVaultConfig.getProperty(NAMESPACE_KEY).get();
       RestTemplateBuilder restTemplateBuilder =
-        util.getRestTemplateWithVaultNamespace(
-          namespace, clientHttpRequestFactory, vaultEndpoint);
+          util.getRestTemplateWithVaultNamespace(
+              namespace, clientHttpRequestFactory, vaultEndpoint);
 
       vaultOperations = new VaultTemplate(restTemplateBuilder, sessionManager);
     } else {

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
@@ -75,7 +75,7 @@ class HashicorpVaultServiceFactory {
       vaultEndpoint = VaultEndpoint.from(uri);
     } catch (URISyntaxException | NoSuchElementException | IllegalArgumentException e) {
       throw new ConfigException(
-          new RuntimeException("Provided Hashicorp Vault url is incorrectly formatted", e));
+          new HashicorpVaultException("Provided Hashicorp Vault url is incorrectly formatted"));
     }
 
     SslConfiguration sslConfiguration = util.configureSsl(keyVaultConfig, envProvider);

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
@@ -1,0 +1,135 @@
+package com.quorum.tessera.key.vault.hashicorp;
+
+import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.ConfigException;
+import com.quorum.tessera.config.KeyVaultConfig;
+import com.quorum.tessera.config.util.EnvironmentVariableProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.vault.authentication.ClientAuthentication;
+import org.springframework.vault.authentication.SessionManager;
+import org.springframework.vault.authentication.SimpleSessionManager;
+import org.springframework.vault.client.RestTemplateBuilder;
+import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.core.VaultOperations;
+import org.springframework.vault.core.VaultTemplate;
+import org.springframework.vault.support.ClientOptions;
+import org.springframework.vault.support.SslConfiguration;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static com.quorum.tessera.config.util.EnvironmentVariables.*;
+import static com.quorum.tessera.key.vault.hashicorp.HashicorpKeyVaultServiceFactoryUtil.NAMESPACE_KEY;
+
+class HashicorpVaultServiceFactory {
+
+  private static final Logger LOGGER =
+    LoggerFactory.getLogger(HashicorpVaultServiceFactory.class);
+
+  <R> R create(
+    Config config,
+    EnvironmentVariableProvider envProvider,
+    HashicorpKeyVaultServiceFactoryUtil util,
+    Function<Config, KeyVaultConfig> keyVaultConfigProvider,
+    BiFunction<VaultOperations, KeyVaultConfig, R> keyVaultServiceProvider
+
+    ) {
+    Objects.requireNonNull(config);
+    Objects.requireNonNull(envProvider);
+    Objects.requireNonNull(util);
+    Objects.requireNonNull(keyVaultConfigProvider);
+    Objects.requireNonNull(keyVaultServiceProvider);
+
+    final String roleId = envProvider.getEnv(HASHICORP_ROLE_ID);
+    final String secretId = envProvider.getEnv(HASHICORP_SECRET_ID);
+    final String authToken = envProvider.getEnv(HASHICORP_TOKEN);
+
+    if (roleId == null && secretId == null && authToken == null) {
+      throw new HashicorpCredentialNotSetException(
+        "Environment variables must be set to authenticate with Hashicorp Vault.  Set the "
+          + HASHICORP_ROLE_ID
+          + " and "
+          + HASHICORP_SECRET_ID
+          + " environment variables if using the AppRole authentication method.  Set the "
+          + HASHICORP_TOKEN
+          + " environment variable if using another authentication method.");
+    } else if (isOnlyOneInputNull(roleId, secretId)) {
+      throw new HashicorpCredentialNotSetException(
+        "Only one of the "
+          + HASHICORP_ROLE_ID
+          + " and "
+          + HASHICORP_SECRET_ID
+          + " environment variables to authenticate with Hashicorp Vault using the AppRole method has been set");
+    }
+
+    KeyVaultConfig keyVaultConfig = keyVaultConfigProvider.apply(config);
+
+    VaultEndpoint vaultEndpoint;
+
+    try {
+      URI uri = new URI(keyVaultConfig.getProperty("url").get());
+      LOGGER.info("URL for Hashicorp key vault is {}", keyVaultConfig.getProperty("url").get());
+      vaultEndpoint = VaultEndpoint.from(uri);
+    } catch (URISyntaxException | NoSuchElementException | IllegalArgumentException e) {
+      throw new ConfigException(
+        new RuntimeException("Provided Hashicorp Vault url is incorrectly formatted", e));
+    }
+
+    SslConfiguration sslConfiguration = util.configureSsl(keyVaultConfig, envProvider);
+
+    ClientOptions clientOptions = new ClientOptions();
+
+    ClientHttpRequestFactory clientHttpRequestFactory =
+      util.createClientHttpRequestFactory(clientOptions, sslConfiguration);
+
+    ClientAuthentication clientAuthentication =
+      util.configureClientAuthentication(
+        keyVaultConfig, envProvider, clientHttpRequestFactory, vaultEndpoint);
+
+    SessionManager sessionManager = new SimpleSessionManager(clientAuthentication);
+
+    VaultOperations vaultOperations =
+      getVaultOperations(
+        keyVaultConfig, vaultEndpoint, clientHttpRequestFactory, sessionManager, util);
+
+    return keyVaultServiceProvider.apply(vaultOperations, keyVaultConfig);
+  }
+
+  private VaultOperations getVaultOperations(
+    KeyVaultConfig keyVaultConfig,
+    VaultEndpoint vaultEndpoint,
+    ClientHttpRequestFactory clientHttpRequestFactory,
+    SessionManager sessionManager,
+    HashicorpKeyVaultServiceFactoryUtil util) {
+
+    VaultOperations vaultOperations;
+
+    if (keyVaultConfig.hasProperty(NAMESPACE_KEY)
+      && keyVaultConfig.getProperty(NAMESPACE_KEY).isPresent()) {
+      LOGGER.info(
+        "Namespace for Hashicorp key vault is {}",
+        keyVaultConfig.getProperty(NAMESPACE_KEY).get());
+
+      String namespace = keyVaultConfig.getProperty(NAMESPACE_KEY).get();
+      RestTemplateBuilder restTemplateBuilder =
+        util.getRestTemplateWithVaultNamespace(
+          namespace, clientHttpRequestFactory, vaultEndpoint);
+
+      vaultOperations = new VaultTemplate(restTemplateBuilder, sessionManager);
+    } else {
+      vaultOperations = new VaultTemplate(vaultEndpoint, clientHttpRequestFactory, sessionManager);
+    }
+
+    return vaultOperations;
+  }
+
+  private boolean isOnlyOneInputNull(Object obj1, Object obj2) {
+    return Objects.isNull(obj1) ^ Objects.isNull(obj2);
+  }
+}

--- a/key-vault/hashicorp-key-vault/src/main/java/module-info.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/module-info.java
@@ -10,4 +10,6 @@ module tessera.keyvault.hashicorp {
 
   provides com.quorum.tessera.key.vault.KeyVaultServiceFactory with
       com.quorum.tessera.key.vault.hashicorp.HashicorpKeyVaultServiceFactory;
+  provides com.quorum.tessera.key.vault.DbCredentialsVaultServiceFactory with
+      com.quorum.tessera.key.vault.hashicorp.HashicorpDbCredentialsVaultServiceFactory;
 }

--- a/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/DbCredentials.java
+++ b/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/DbCredentials.java
@@ -1,0 +1,9 @@
+package com.quorum.tessera.key.vault;
+
+public interface DbCredentials {
+  String getUsername();
+
+  String getPassword();
+
+  long getLeaseDurationInSec();
+}

--- a/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/DbCredentialsVaultService.java
+++ b/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/DbCredentialsVaultService.java
@@ -1,0 +1,5 @@
+package com.quorum.tessera.key.vault;
+
+public interface DbCredentialsVaultService {
+  DbCredentials getDbCredentials();
+}

--- a/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/DbCredentialsVaultServiceFactory.java
+++ b/key-vault/key-vault-api/src/main/java/com/quorum/tessera/key/vault/DbCredentialsVaultServiceFactory.java
@@ -1,0 +1,24 @@
+package com.quorum.tessera.key.vault;
+
+import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.KeyVaultType;
+import com.quorum.tessera.config.util.EnvironmentVariableProvider;
+import java.util.ServiceLoader;
+
+public interface DbCredentialsVaultServiceFactory {
+  DbCredentialsVaultService create(Config config, EnvironmentVariableProvider envProvider);
+
+  KeyVaultType getType();
+
+  static DbCredentialsVaultServiceFactory getInstance(KeyVaultType keyVaultType) {
+    return ServiceLoader.load(DbCredentialsVaultServiceFactory.class).stream()
+        .map(ServiceLoader.Provider::get)
+        .filter(factory -> factory.getType() == keyVaultType)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new NoKeyVaultServiceFactoryException(
+                    keyVaultType
+                        + " implementation of DbCredentialVaultService was not found on the classpath"));
+  }
+}

--- a/key-vault/key-vault-api/src/main/java/module-info.java
+++ b/key-vault/key-vault-api/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module tessera.keyvault.api {
   requires tessera.shared;
 
   uses com.quorum.tessera.key.vault.KeyVaultServiceFactory;
+  uses com.quorum.tessera.key.vault.DbCredentialsVaultServiceFactory;
 
   exports com.quorum.tessera.key.vault;
 }

--- a/tessera-data/build.gradle
+++ b/tessera-data/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation project(":enclave:enclave-api")
   implementation project(":encryption:encryption-api")
   implementation project(":eclipselink-utils")
+  implementation project(":key-vault:key-vault-api")
   implementation "jakarta.transaction:jakarta.transaction-api"
   implementation "org.bouncycastle:bcprov-jdk18on"
   implementation "jakarta.validation:jakarta.validation-api"

--- a/tessera-data/src/main/java/com/quorum/tessera/data/internal/DbCredentialsVaultLifecycleManager.java
+++ b/tessera-data/src/main/java/com/quorum/tessera/data/internal/DbCredentialsVaultLifecycleManager.java
@@ -1,0 +1,131 @@
+package com.quorum.tessera.data.internal;
+
+import com.quorum.tessera.config.JdbcConfig;
+import com.quorum.tessera.key.vault.DbCredentialsVaultService;
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DbCredentialsVaultLifecycleManager {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DbCredentialsVaultLifecycleManager.class);
+
+  private final DbCredentialsVaultService dbCredentialsVaultService;
+  private final JdbcConfig jdbcConfig;
+
+  private final HikariDataSource hikariDataSource;
+
+  private final ScheduledExecutorService scheduledExecutorService;
+
+  private final long retryDelayInSeconds = 2;
+  private int maxRetryDelayInSeconds = 60;
+  private int retryCount = 0;
+
+  private final long minDelayBeforeNextRunFactor = 10;
+  private final double delayBeforeNextRunFactor = 0.1;
+  private final long maxDurationBeforeTtlExpireInSeconds = 300;
+
+  private long getDelayBeforeNextRunInSecondsBasedOnTtl(final long ttlInSeconds) {
+    var durationBeforeTtlExpire = (long) Math.ceil(ttlInSeconds * delayBeforeNextRunFactor);
+    durationBeforeTtlExpire =
+        Math.min(durationBeforeTtlExpire, maxDurationBeforeTtlExpireInSeconds);
+    var delayBeforeNextRunInSeconds = ttlInSeconds - durationBeforeTtlExpire;
+    return Math.max(delayBeforeNextRunInSeconds, minDelayBeforeNextRunFactor);
+  }
+
+  private long getRetryDelayInSeconds() {
+    var factor = 2;
+    var maxRetryCount =
+        (int) (Math.log((double) maxRetryDelayInSeconds / retryDelayInSeconds) / Math.log(factor));
+
+    if (retryCount > maxRetryCount) {
+      retryCount = maxRetryCount;
+      return maxRetryDelayInSeconds;
+    }
+
+    return retryDelayInSeconds * (long) Math.pow(factor, retryCount);
+  }
+
+  private void checkAndRetrieveNewDbCredentials() {
+    try {
+      LOGGER.info("Checking for new db credentials from vault ...");
+
+      final var credentials = dbCredentialsVaultService.getDbCredentials();
+      final long adjustedDelayBeforeNextRunInSeconds =
+          getDelayBeforeNextRunInSecondsBasedOnTtl(credentials.getLeaseDurationInSec());
+
+      final var hikariConfigMXBean = hikariDataSource.getHikariConfigMXBean();
+      hikariConfigMXBean.setUsername(credentials.getUsername());
+      hikariConfigMXBean.setPassword(credentials.getPassword());
+
+      final var hikariPoolMXBean = hikariDataSource.getHikariPoolMXBean();
+      hikariPoolMXBean.softEvictConnections();
+
+      scheduledExecutorService.schedule(
+          this::checkAndRetrieveNewDbCredentials,
+          adjustedDelayBeforeNextRunInSeconds,
+          TimeUnit.SECONDS);
+      retryCount = 0;
+      LOGGER.info(
+          "Checking for new db credentials from vault was successful. checking again after {} seconds",
+          adjustedDelayBeforeNextRunInSeconds);
+    } catch (Exception ex) {
+      var delayInSeconds = getRetryDelayInSeconds();
+      LOGGER.error(
+          "Unexpected error while fetching new db credentials. Retrying after {} seconds. Error: {}",
+          delayInSeconds,
+          getNestedExceptionMessagesSummary(ex));
+      LOGGER.debug("Error details", ex);
+      scheduledExecutorService.schedule(
+          this::checkAndRetrieveNewDbCredentials, delayInSeconds, TimeUnit.SECONDS);
+      retryCount++;
+    }
+  }
+
+  public DbCredentialsVaultLifecycleManager(
+      DbCredentialsVaultService dbCredentialsVaultService,
+      JdbcConfig jdbcConfig,
+      HikariDataSource hikariDataSource) {
+    this.dbCredentialsVaultService = dbCredentialsVaultService;
+    this.jdbcConfig = jdbcConfig;
+    this.hikariDataSource = hikariDataSource;
+    this.scheduledExecutorService = Executors.newScheduledThreadPool(2);
+  }
+
+  String getNestedExceptionMessagesSummary(Throwable e) {
+    StringBuilder sb = new StringBuilder();
+    int levelCount = 0;
+    final int maxLevelCount = 5;
+    while (e != null) {
+      if (levelCount > 0) {
+        sb.append(". ");
+      }
+      sb.append(e.getMessage());
+      e = e.getCause();
+      levelCount++;
+      if (levelCount > maxLevelCount) {
+        sb.append("...");
+        break;
+      }
+    }
+    return sb.toString();
+  }
+
+  public void start(final long initialDelayInSeconds) {
+    LOGGER.info("Component for managing life-cycle of db credentials in vault is starting ...");
+    var adjustedDelayInSeconds = getDelayBeforeNextRunInSecondsBasedOnTtl(initialDelayInSeconds);
+    scheduledExecutorService.schedule(
+        this::checkAndRetrieveNewDbCredentials, adjustedDelayInSeconds, TimeUnit.SECONDS);
+    LOGGER.info(
+        "Component for managing life-cycle of db credentials in vault is successfully started. Next schedule is after {} seconds",
+        adjustedDelayInSeconds);
+  }
+
+  public void stop() {
+    scheduledExecutorService.shutdown();
+  }
+}

--- a/tessera-data/src/main/java/com/quorum/tessera/data/internal/DbCredentialsVaultLifecycleManager.java
+++ b/tessera-data/src/main/java/com/quorum/tessera/data/internal/DbCredentialsVaultLifecycleManager.java
@@ -25,7 +25,7 @@ public class DbCredentialsVaultLifecycleManager {
   private int maxRetryDelayInSeconds = 60;
   private int retryCount = 0;
 
-  private final long minDelayBeforeNextRunFactor = 10;
+  private final long minDelayBeforeNextRunInSeconds = 10;
   private final double delayBeforeNextRunFactor = 0.1;
   private final long maxDurationBeforeTtlExpireInSeconds = 300;
 
@@ -34,7 +34,7 @@ public class DbCredentialsVaultLifecycleManager {
     durationBeforeTtlExpire =
         Math.min(durationBeforeTtlExpire, maxDurationBeforeTtlExpireInSeconds);
     var delayBeforeNextRunInSeconds = ttlInSeconds - durationBeforeTtlExpire;
-    return Math.max(delayBeforeNextRunInSeconds, minDelayBeforeNextRunFactor);
+    return Math.max(delayBeforeNextRunInSeconds, minDelayBeforeNextRunInSeconds);
   }
 
   private long getRetryDelayInSeconds() {

--- a/tessera-data/src/main/java/com/quorum/tessera/data/internal/DbCredentialsVaultLifecycleManager.java
+++ b/tessera-data/src/main/java/com/quorum/tessera/data/internal/DbCredentialsVaultLifecycleManager.java
@@ -1,11 +1,15 @@
 package com.quorum.tessera.data.internal;
 
+import com.quorum.tessera.config.ConfigException;
 import com.quorum.tessera.config.JdbcConfig;
 import com.quorum.tessera.key.vault.DbCredentialsVaultService;
 import com.zaxxer.hikari.HikariDataSource;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,13 +25,12 @@ public class DbCredentialsVaultLifecycleManager {
 
   private final ScheduledExecutorService scheduledExecutorService;
 
-  private final long retryDelayInSeconds = 2;
+  private long retryDelayInSeconds = 2;
   private int maxRetryDelayInSeconds = 60;
   private int retryCount = 0;
-
-  private final long minDelayBeforeNextRunInSeconds = 10;
-  private final double delayBeforeNextRunFactor = 0.1;
-  private final long maxDurationBeforeTtlExpireInSeconds = 300;
+  private long minDelayBeforeNextRunInSeconds = 10;
+  private double delayBeforeNextRunFactor = 0.1;
+  private long maxDurationBeforeTtlExpireInSeconds = 300;
 
   private long getDelayBeforeNextRunInSecondsBasedOnTtl(final long ttlInSeconds) {
     var durationBeforeTtlExpire = (long) Math.ceil(ttlInSeconds * delayBeforeNextRunFactor);
@@ -94,6 +97,7 @@ public class DbCredentialsVaultLifecycleManager {
     this.jdbcConfig = jdbcConfig;
     this.hikariDataSource = hikariDataSource;
     this.scheduledExecutorService = Executors.newScheduledThreadPool(2);
+    getAndAssignConfigurations();
   }
 
   String getNestedExceptionMessagesSummary(Throwable e) {
@@ -115,6 +119,118 @@ public class DbCredentialsVaultLifecycleManager {
     return sb.toString();
   }
 
+  private void getAndAssignConfigurations() {
+    var vaultDbCredentialsConfig = jdbcConfig.getHashicorpVaultDbCredentialsConfig();
+    var errors = new ArrayList<String>();
+    this.retryDelayInSeconds =
+        validateAndConvertValue(
+            "retryDelayInSeconds",
+            vaultDbCredentialsConfig.getRetryDelayInSeconds(),
+            Long::parseLong,
+            List.of(this::validateValueShouldBeGreaterThanZero),
+            2L,
+            errors);
+    this.maxRetryDelayInSeconds =
+        validateAndConvertValue(
+            "maxRetryDelayInSeconds",
+            vaultDbCredentialsConfig.getMaxRetryDelayInSeconds(),
+            Integer::parseInt,
+            List.of(this::validateValueShouldBeGreaterThanZero),
+            60,
+            errors);
+    this.minDelayBeforeNextRunInSeconds =
+        validateAndConvertValue(
+            "minDelayBeforeNextRunInSeconds",
+            vaultDbCredentialsConfig.getMinDelayBeforeNextRunInSeconds(),
+            Long::parseLong,
+            List.of(this::validateValueShouldBeGreaterThanZero),
+            10L,
+            errors);
+    this.delayBeforeNextRunFactor =
+        validateAndConvertValue(
+            "delayBeforeNextRunFactor",
+            vaultDbCredentialsConfig.getDelayBeforeNextRunFactor(),
+            Double::parseDouble,
+            List.of(this::validateValueShouldBeGreaterThanZero),
+            0.1,
+            errors);
+    this.maxDurationBeforeTtlExpireInSeconds =
+        validateAndConvertValue(
+            "maxDurationBeforeTtlExpireInSeconds",
+            vaultDbCredentialsConfig.getMaxDurationBeforeTtlExpireInSeconds(),
+            Long::parseLong,
+            List.of(this::validateValueShouldBeGreaterThanZero),
+            300L,
+            errors);
+    if (!errors.isEmpty()) {
+      throw new ConfigException(new Exception(String.join(" ", errors)));
+    }
+  }
+
+  private <R> R validateAndConvertValue(
+      final String propertyName,
+      final String value,
+      Function<String, R> converter,
+      final R defaultValue,
+      List<String> outputError) {
+
+    return validateAndConvertValue(
+        propertyName, value, converter, List.of(), defaultValue, outputError);
+  }
+
+  private <R> R validateAndConvertValue(
+      final String propertyName,
+      final String value,
+      Function<String, R> converter,
+      List<TriConsumer<String, R, List<String>>> validators,
+      final R defaultValue,
+      List<String> outputError) {
+    if (value == null) {
+      return defaultValue;
+    }
+    try {
+      var convertedValue = converter.apply(value);
+      for (var validator : validators) {
+        validator.accept(propertyName, convertedValue, outputError);
+      }
+      return convertedValue;
+    } catch (Exception ex) {
+      outputError.add(
+          String.format(
+              "The value \"%s\" of property [%s] is not a valid [%s] type.",
+              value, propertyName, defaultValue.getClass().getSimpleName()));
+    }
+    return defaultValue;
+  }
+
+  private void validateValueShouldBeGreaterThanZero(
+      String propertyName, Number value, List<String> outputError) {
+    if ((value instanceof Double && value.doubleValue() <= 0)
+        || (value instanceof Integer && value.intValue() <= 0)
+        || (value instanceof Long && value.longValue() <= 0)) {
+      outputError.add(
+          String.format(
+              "Configuration property \"%s\" should have a value greater than zero (0).",
+              propertyName));
+    }
+  }
+
+  private void logStartupConfiguration() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("retryDelayInSeconds=").append(this.retryDelayInSeconds).append("; ");
+    sb.append("maxRetryDelayInSeconds=").append(this.maxRetryDelayInSeconds).append("; ");
+    sb.append("minDelayBeforeNextRunInSeconds=")
+        .append(this.minDelayBeforeNextRunInSeconds)
+        .append("; ");
+    sb.append("delayBeforeNextRunFactor=").append(this.delayBeforeNextRunFactor).append("; ");
+    sb.append("maxDurationBeforeTtlExpireInSeconds=")
+        .append(this.maxDurationBeforeTtlExpireInSeconds)
+        .append("; ");
+    LOGGER.info(
+        "Component for managing life-cycle of db credentials in vault started with configurations: {}",
+        sb.toString());
+  }
+
   public void start(final long initialDelayInSeconds) {
     LOGGER.info("Component for managing life-cycle of db credentials in vault is starting ...");
     var adjustedDelayInSeconds = getDelayBeforeNextRunInSecondsBasedOnTtl(initialDelayInSeconds);
@@ -123,9 +239,15 @@ public class DbCredentialsVaultLifecycleManager {
     LOGGER.info(
         "Component for managing life-cycle of db credentials in vault is successfully started. Next schedule is after {} seconds",
         adjustedDelayInSeconds);
+    logStartupConfiguration();
   }
 
   public void stop() {
     scheduledExecutorService.shutdown();
+  }
+
+  @FunctionalInterface
+  public interface TriConsumer<T, U, V> {
+    void accept(T t, U u, V v);
   }
 }

--- a/tessera-data/src/main/java/com/quorum/tessera/data/internal/DbCredentialsVaultLifecycleManager.java
+++ b/tessera-data/src/main/java/com/quorum/tessera/data/internal/DbCredentialsVaultLifecycleManager.java
@@ -104,12 +104,13 @@ public class DbCredentialsVaultLifecycleManager {
     StringBuilder sb = new StringBuilder();
     int levelCount = 0;
     final int maxLevelCount = 5;
-    while (e != null) {
+    var exception = e;
+    while (exception != null) {
       if (levelCount > 0) {
         sb.append(". ");
       }
-      sb.append(e.getMessage());
-      e = e.getCause();
+      sb.append(exception.getMessage());
+      exception = exception.getCause();
       levelCount++;
       if (levelCount > maxLevelCount) {
         sb.append("...");
@@ -163,19 +164,8 @@ public class DbCredentialsVaultLifecycleManager {
             300L,
             errors);
     if (!errors.isEmpty()) {
-      throw new ConfigException(new Exception(String.join(" ", errors)));
+      throw new ConfigException(String.join(" ", errors));
     }
-  }
-
-  private <R> R validateAndConvertValue(
-      final String propertyName,
-      final String value,
-      Function<String, R> converter,
-      final R defaultValue,
-      List<String> outputError) {
-
-    return validateAndConvertValue(
-        propertyName, value, converter, List.of(), defaultValue, outputError);
   }
 
   private <R> R validateAndConvertValue(

--- a/tessera-data/src/main/java/com/quorum/tessera/data/internal/HikariDataSourceFactory.java
+++ b/tessera-data/src/main/java/com/quorum/tessera/data/internal/HikariDataSourceFactory.java
@@ -1,6 +1,5 @@
 package com.quorum.tessera.data.internal;
 
-import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.ConfigFactory;
 import com.quorum.tessera.config.JdbcConfig;
 import com.quorum.tessera.config.KeyVaultType;
@@ -18,12 +17,6 @@ public enum HikariDataSourceFactory implements DataSourceFactory {
 
   private DataSource dataSource;
 
-  private final Config rootConfig;
-
-  HikariDataSourceFactory() {
-    this.rootConfig = ConfigFactory.create().getConfig();
-  }
-
   @Override
   public DataSource create(JdbcConfig config) {
     if (dataSource != null) {
@@ -35,7 +28,8 @@ public enum HikariDataSourceFactory implements DataSourceFactory {
     final HikariConfig hikariConfig = new HikariConfig();
     hikariConfig.setJdbcUrl(config.getUrl());
 
-    if (isDbCredentialsVaultConfigPresent()) {
+    if (isDbCredentialsVaultConfigPresent(config)) {
+      final var rootConfig = ConfigFactory.create().getConfig();
       final var dbCredentialsVaultService =
           DbCredentialsVaultServiceFactory.getInstance(KeyVaultType.HASHICORP)
               .create(rootConfig, new EnvironmentVariableProvider());
@@ -60,9 +54,8 @@ public enum HikariDataSourceFactory implements DataSourceFactory {
     return dataSource;
   }
 
-  private boolean isDbCredentialsVaultConfigPresent() {
-    var hashicorpVaultDbCredentialsConfig =
-        this.rootConfig.getJdbcConfig().getHashicorpVaultDbCredentialsConfig();
+  private boolean isDbCredentialsVaultConfigPresent(JdbcConfig config) {
+    final var hashicorpVaultDbCredentialsConfig = config.getHashicorpVaultDbCredentialsConfig();
     return hashicorpVaultDbCredentialsConfig != null
         && hashicorpVaultDbCredentialsConfig.getKeyVaultType() == KeyVaultType.HASHICORP;
   }

--- a/tessera-data/src/main/java/com/quorum/tessera/data/internal/HikariDataSourceFactory.java
+++ b/tessera-data/src/main/java/com/quorum/tessera/data/internal/HikariDataSourceFactory.java
@@ -1,16 +1,29 @@
 package com.quorum.tessera.data.internal;
 
+import com.quorum.tessera.config.Config;
+import com.quorum.tessera.config.ConfigFactory;
 import com.quorum.tessera.config.JdbcConfig;
+import com.quorum.tessera.config.KeyVaultType;
 import com.quorum.tessera.config.util.EncryptedStringResolver;
+import com.quorum.tessera.config.util.EnvironmentVariableProvider;
 import com.quorum.tessera.data.DataSourceFactory;
+import com.quorum.tessera.key.vault.DbCredentials;
+import com.quorum.tessera.key.vault.DbCredentialsVaultServiceFactory;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+
 import javax.sql.DataSource;
 
 public enum HikariDataSourceFactory implements DataSourceFactory {
   INSTANCE;
 
   private DataSource dataSource;
+
+  private final Config rootConfig;
+
+  HikariDataSourceFactory(){
+    this.rootConfig = ConfigFactory.create().getConfig();
+  }
 
   @Override
   public DataSource create(JdbcConfig config) {
@@ -22,12 +35,25 @@ public enum HikariDataSourceFactory implements DataSourceFactory {
 
     final HikariConfig hikariConfig = new HikariConfig();
     hikariConfig.setJdbcUrl(config.getUrl());
-    hikariConfig.setUsername(config.getUsername());
-    hikariConfig.setPassword(resolver.resolve(config.getPassword()));
+
+    if (isDbCredentialsVaultConfigPresent()) {
+      final var dbCredentialsVaultService =
+        DbCredentialsVaultServiceFactory.getInstance(KeyVaultType.HASHICORP).create(rootConfig, new EnvironmentVariableProvider());
+      final DbCredentials dbCredentials = dbCredentialsVaultService.getDbCredentials();
+      hikariConfig.setUsername(dbCredentials.getUsername());
+      hikariConfig.setPassword(dbCredentials.getPassword());
+    } else {
+      hikariConfig.setUsername(config.getUsername());
+      hikariConfig.setPassword(resolver.resolve(config.getPassword()));
+    }
 
     dataSource = new HikariDataSource(hikariConfig);
-
     return dataSource;
+  }
+
+  private boolean isDbCredentialsVaultConfigPresent(){
+    var hashicorpVaultDbCredentialsConfig = this.rootConfig.getJdbcConfig().getHashicorpVaultDbCredentialsConfig();
+    return hashicorpVaultDbCredentialsConfig != null && hashicorpVaultDbCredentialsConfig.getKeyVaultType()==KeyVaultType.HASHICORP;
   }
 
   protected void clear() {

--- a/tessera-data/src/main/java/module-info.java
+++ b/tessera-data/src/main/java/module-info.java
@@ -12,6 +12,7 @@ open module tessera.data {
   requires com.zaxxer.hikari;
   requires jakarta.validation;
   requires tessera.eclipselink.utils;
+  requires tessera.keyvault.api;
 
   //    opens com.quorum.tessera.data to org.eclipse.persistence.core;
   //    opens com.quorum.tessera.data.staging to org.eclipse.persistence.core;
@@ -25,6 +26,7 @@ open module tessera.data {
   uses com.quorum.tessera.data.staging.StagingEntityDAO;
   uses com.quorum.tessera.data.DataSourceFactory;
   uses com.quorum.tessera.data.PrivacyGroupDAO;
+  uses com.quorum.tessera.key.vault.DbCredentialsVaultServiceFactory;
 
   provides com.quorum.tessera.data.EncryptedTransactionDAO with
       com.quorum.tessera.data.internal.EncryptedTransactionDAOProvider;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/tessera/blob/master/.github/CONTRIBUTING.md -->

## PR Description

Support DB credential storage and password rotation via Hashicorp Vault. For more details, view related ticket SET-559.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
