### PR TITLE
Added Environment Variables for Authentication to Vault DB Secret Engine

### DIFF
--- a/config/src/main/java/com/quorum/tessera/config/util/EnvironmentVariables.java
+++ b/config/src/main/java/com/quorum/tessera/config/util/EnvironmentVariables.java
@@ -24,6 +24,12 @@ public final class EnvironmentVariables {
 
   public static final String HASHICORP_TOKEN = "HASHICORP_TOKEN";
 
+  public static final String HASHICORP_DSE_ROLE_ID = "HASHICORP_DSE_ROLE_ID";
+
+  public static final String HASHICORP_DSE_SECRET_ID = "HASHICORP_DSE_SECRET_ID";
+
+  public static final String HASHICORP_DSE_TOKEN = "HASHICORP_DSE_TOKEN";
+
   public static final String HASHICORP_CLIENT_KEYSTORE_PWD = "HASHICORP_CLIENT_KEYSTORE_PWD";
 
   public static final String HASHICORP_CLIENT_TRUSTSTORE_PWD = "HASHICORP_CLIENT_TRUSTSTORE_PWD";

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpDbCredentialsVaultServiceFactory.java
@@ -1,5 +1,7 @@
 package com.quorum.tessera.key.vault.hashicorp;
 
+import static com.quorum.tessera.config.util.EnvironmentVariables.*;
+
 import com.quorum.tessera.config.Config;
 import com.quorum.tessera.config.ConfigException;
 import com.quorum.tessera.config.KeyVaultConfig;
@@ -32,7 +34,10 @@ public class HashicorpDbCredentialsVaultServiceFactory extends HashicorpVaultSer
         envProvider,
         util,
         this::getKeyVaultConfig,
-        HashicorpDbCredentialsVaultService::new);
+        HashicorpDbCredentialsVaultService::new,
+        HASHICORP_DSE_ROLE_ID,
+        HASHICORP_DSE_SECRET_ID,
+        HASHICORP_DSE_TOKEN);
   }
 
   private KeyVaultConfig getKeyVaultConfig(Config config) {

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceFactoryUtil.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceFactoryUtil.java
@@ -77,10 +77,28 @@ class HashicorpKeyVaultServiceFactoryUtil {
       EnvironmentVariableProvider envProvider,
       ClientHttpRequestFactory clientHttpRequestFactory,
       VaultEndpoint vaultEndpoint) {
+    return configureClientAuthentication(
+        keyVaultConfig,
+        envProvider,
+        clientHttpRequestFactory,
+        vaultEndpoint,
+        HASHICORP_ROLE_ID,
+        HASHICORP_SECRET_ID,
+        HASHICORP_TOKEN);
+  }
 
-    final String roleId = envProvider.getEnv(HASHICORP_ROLE_ID);
-    final String secretId = envProvider.getEnv(HASHICORP_SECRET_ID);
-    final String authToken = envProvider.getEnv(HASHICORP_TOKEN);
+  ClientAuthentication configureClientAuthentication(
+      KeyVaultConfig keyVaultConfig,
+      EnvironmentVariableProvider envProvider,
+      ClientHttpRequestFactory clientHttpRequestFactory,
+      VaultEndpoint vaultEndpoint,
+      String envVarHashicorpRoleId,
+      String envVarHashicorpSecretId,
+      String envVarHashicorpToken) {
+
+    final String roleId = envProvider.getEnv(envVarHashicorpRoleId);
+    final String secretId = envProvider.getEnv(envVarHashicorpSecretId);
+    final String authToken = envProvider.getEnv(envVarHashicorpToken);
 
     if (roleId != null && secretId != null) {
 
@@ -110,20 +128,20 @@ class HashicorpKeyVaultServiceFactoryUtil {
 
       throw new HashicorpCredentialNotSetException(
           "Both "
-              + HASHICORP_ROLE_ID
+              + envVarHashicorpRoleId
               + " and "
-              + HASHICORP_SECRET_ID
+              + envVarHashicorpSecretId
               + " environment variables must be set to use the AppRole authentication method");
 
     } else if (authToken == null) {
 
       throw new HashicorpCredentialNotSetException(
           "Both "
-              + HASHICORP_ROLE_ID
+              + envVarHashicorpRoleId
               + " and "
-              + HASHICORP_SECRET_ID
+              + envVarHashicorpSecretId
               + " environment variables must be set to use the AppRole authentication method.  Alternatively set "
-              + HASHICORP_TOKEN
+              + envVarHashicorpToken
               + " to authenticate using the Token method");
     }
 

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
@@ -54,7 +54,7 @@ class HashicorpVaultServiceFactory {
       Function<Config, KeyVaultConfig> keyVaultConfigProvider,
       BiFunction<VaultOperations, KeyVaultConfig, R> keyVaultServiceProvider,
       String envVarHashicorpRoleId,
-      String envVarhasHicorpSecretId,
+      String envVarHashicorpSecretId,
       String envVarHashicorpToken) {
 
     Objects.requireNonNull(config);
@@ -64,7 +64,7 @@ class HashicorpVaultServiceFactory {
     Objects.requireNonNull(keyVaultServiceProvider);
 
     final String roleId = envProvider.getEnv(envVarHashicorpRoleId);
-    final String secretId = envProvider.getEnv(envVarhasHicorpSecretId);
+    final String secretId = envProvider.getEnv(envVarHashicorpSecretId);
     final String authToken = envProvider.getEnv(envVarHashicorpToken);
 
     if (roleId == null && secretId == null && authToken == null) {
@@ -72,7 +72,7 @@ class HashicorpVaultServiceFactory {
           "Environment variables must be set to authenticate with Hashicorp Vault.  Set the "
               + envVarHashicorpRoleId
               + " and "
-              + envVarhasHicorpSecretId
+              + envVarHashicorpSecretId
               + " environment variables if using the AppRole authentication method.  Set the "
               + envVarHashicorpToken
               + " environment variable if using another authentication method.");
@@ -81,7 +81,7 @@ class HashicorpVaultServiceFactory {
           "Only one of the "
               + envVarHashicorpRoleId
               + " and "
-              + envVarhasHicorpSecretId
+              + envVarHashicorpSecretId
               + " environment variables to authenticate with Hashicorp Vault using the AppRole method has been set");
     }
 
@@ -112,7 +112,7 @@ class HashicorpVaultServiceFactory {
             clientHttpRequestFactory,
             vaultEndpoint,
             envVarHashicorpRoleId,
-            envVarhasHicorpSecretId,
+            envVarHashicorpSecretId,
             envVarHashicorpToken);
 
     SessionManager sessionManager = new SimpleSessionManager(clientAuthentication);

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
@@ -36,6 +36,26 @@ class HashicorpVaultServiceFactory {
       HashicorpKeyVaultServiceFactoryUtil util,
       Function<Config, KeyVaultConfig> keyVaultConfigProvider,
       BiFunction<VaultOperations, KeyVaultConfig, R> keyVaultServiceProvider) {
+    return create(
+        config,
+        envProvider,
+        util,
+        keyVaultConfigProvider,
+        keyVaultServiceProvider,
+        HASHICORP_ROLE_ID,
+        HASHICORP_SECRET_ID,
+        HASHICORP_TOKEN);
+  }
+
+  <R> R create(
+      Config config,
+      EnvironmentVariableProvider envProvider,
+      HashicorpKeyVaultServiceFactoryUtil util,
+      Function<Config, KeyVaultConfig> keyVaultConfigProvider,
+      BiFunction<VaultOperations, KeyVaultConfig, R> keyVaultServiceProvider,
+      String envVarHashicorpRoleId,
+      String envVarhasHicorpSecretId,
+      String envVarHashicorpToken) {
 
     Objects.requireNonNull(config);
     Objects.requireNonNull(envProvider);
@@ -43,25 +63,25 @@ class HashicorpVaultServiceFactory {
     Objects.requireNonNull(keyVaultConfigProvider);
     Objects.requireNonNull(keyVaultServiceProvider);
 
-    final String roleId = envProvider.getEnv(HASHICORP_ROLE_ID);
-    final String secretId = envProvider.getEnv(HASHICORP_SECRET_ID);
-    final String authToken = envProvider.getEnv(HASHICORP_TOKEN);
+    final String roleId = envProvider.getEnv(envVarHashicorpRoleId);
+    final String secretId = envProvider.getEnv(envVarhasHicorpSecretId);
+    final String authToken = envProvider.getEnv(envVarHashicorpToken);
 
     if (roleId == null && secretId == null && authToken == null) {
       throw new HashicorpCredentialNotSetException(
           "Environment variables must be set to authenticate with Hashicorp Vault.  Set the "
-              + HASHICORP_ROLE_ID
+              + envVarHashicorpRoleId
               + " and "
-              + HASHICORP_SECRET_ID
+              + envVarhasHicorpSecretId
               + " environment variables if using the AppRole authentication method.  Set the "
-              + HASHICORP_TOKEN
+              + envVarHashicorpToken
               + " environment variable if using another authentication method.");
     } else if (isOnlyOneInputNull(roleId, secretId)) {
       throw new HashicorpCredentialNotSetException(
           "Only one of the "
-              + HASHICORP_ROLE_ID
+              + envVarHashicorpRoleId
               + " and "
-              + HASHICORP_SECRET_ID
+              + envVarhasHicorpSecretId
               + " environment variables to authenticate with Hashicorp Vault using the AppRole method has been set");
     }
 
@@ -87,7 +107,13 @@ class HashicorpVaultServiceFactory {
 
     ClientAuthentication clientAuthentication =
         util.configureClientAuthentication(
-            keyVaultConfig, envProvider, clientHttpRequestFactory, vaultEndpoint);
+            keyVaultConfig,
+            envProvider,
+            clientHttpRequestFactory,
+            vaultEndpoint,
+            envVarHashicorpRoleId,
+            envVarhasHicorpSecretId,
+            envVarHashicorpToken);
 
     SessionManager sessionManager = new SimpleSessionManager(clientAuthentication);
 

--- a/key-vault/hashicorp-key-vault/src/test/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceFactoryTest.java
+++ b/key-vault/hashicorp-key-vault/src/test/java/com/quorum/tessera/key/vault/hashicorp/HashicorpKeyVaultServiceFactoryTest.java
@@ -268,6 +268,15 @@ public class HashicorpKeyVaultServiceFactoryTest {
             eq(clientHttpRequestFactory),
             any(VaultEndpoint.class)))
         .thenReturn(clientAuthentication);
+    when(keyVaultServiceFactoryUtil.configureClientAuthentication(
+            eq(keyVaultConfig),
+            eq(envProvider),
+            eq(clientHttpRequestFactory),
+            any(VaultEndpoint.class),
+            anyString(),
+            anyString(),
+            anyString()))
+        .thenReturn(clientAuthentication);
     when(keyVaultServiceFactoryUtil.getRestTemplateWithVaultNamespace(
             anyString(), eq(clientHttpRequestFactory), any(VaultEndpoint.class)))
         .thenReturn(restTemplateBuilder);

--- a/tests/acceptance-test/src/test/resources/features/vault/hashicorp-db-secret-engine.feature
+++ b/tests/acceptance-test/src/test/resources/features/vault/hashicorp-db-secret-engine.feature
@@ -18,3 +18,4 @@ Feature: Hashicorp Vault support with DB Secret Engine
     -configfile %s -pidfile %s -o jdbc.autoCreateTables=true
     """
     Then Tessera will retrieve the key pair from the vault
+    Then Tessera will fetch a missing transaction and successfully get a response of not found


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/tessera/blob/master/.github/CONTRIBUTING.md -->

## PR Description

Support DB credential storage and password rotation via Hashicorp Vault. For more details, view related ticket SET-559.
Introduced following environment variable to facilitate authentication with Vault database secret engine.

- HASHICORP_DSE_ROLE_ID
- HASHICORP_DSE_SECRET_ID
- HASHICORP_DSE_TOKEN

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
