### PR TITLE
SET-559 Tessera optimization for edge-case handling near rotation period of static db credential by Vault

### DIFF
--- a/tessera-data/src/main/java/com/quorum/tessera/data/internal/DbCredentialsVaultLifecycleManager.java
+++ b/tessera-data/src/main/java/com/quorum/tessera/data/internal/DbCredentialsVaultLifecycleManager.java
@@ -57,16 +57,16 @@ public class DbCredentialsVaultLifecycleManager {
     return retryDelayInSeconds * (long) Math.pow(factor, retryCount);
   }
 
-  private void keepTrackOfCurrentDbCredentials(DbCredentials credentials){
+  private void keepTrackOfCurrentDbCredentials(DbCredentials credentials) {
     this.currentDbCredentials = credentials;
   }
 
-  private boolean isDbCredentialChanged(DbCredentials newCredentials){
-    if (this.currentDbCredentials == null){
+  private boolean isDbCredentialChanged(DbCredentials newCredentials) {
+    if (this.currentDbCredentials == null) {
       return true;
     }
-    return !Objects.equals(this.currentDbCredentials.getUsername(), newCredentials.getUsername()) ||
-      !Objects.equals(this.currentDbCredentials.getPassword(), newCredentials.getPassword());
+    return !Objects.equals(this.currentDbCredentials.getUsername(), newCredentials.getUsername())
+        || !Objects.equals(this.currentDbCredentials.getPassword(), newCredentials.getPassword());
   }
 
   private void checkAndRetrieveNewDbCredentials() {
@@ -89,9 +89,9 @@ public class DbCredentialsVaultLifecycleManager {
         LOGGER.info("Db credentials changed. Updated the connection pool successfully.");
       }
       scheduledExecutorService.schedule(
-        this::checkAndRetrieveNewDbCredentials,
-        adjustedDelayBeforeNextRunInSeconds,
-        TimeUnit.SECONDS);
+          this::checkAndRetrieveNewDbCredentials,
+          adjustedDelayBeforeNextRunInSeconds,
+          TimeUnit.SECONDS);
       retryCount = 0;
       LOGGER.info(
           "Checking for new db credentials from vault was successful. checking again after {} seconds",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/tessera/blob/master/.github/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
Tessera optimization for edge-case handling near rotation period of static db credential by Vault.
This is to cater for edge-case scenario near the time of rotation of db credentials by Vault. The Tessera db credential life-cycle manager first checks if the DB credentials indeed changed before refreshing underlying datasource and connection pool. 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
