### PR TITLE
Manage the Vault Auth Token renewal

### DIFF
--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpSimpleSessionManager.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpSimpleSessionManager.java
@@ -1,18 +1,16 @@
 package com.quorum.tessera.key.vault.hashicorp;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 import org.springframework.vault.authentication.ClientAuthentication;
 import org.springframework.vault.authentication.LoginToken;
 import org.springframework.vault.authentication.SessionManager;
-import org.springframework.vault.authentication.SimpleSessionManager;
 import org.springframework.vault.support.VaultToken;
-
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Optional;
-import java.util.concurrent.locks.ReentrantLock;
 
 public class HashicorpSimpleSessionManager implements SessionManager {
 
@@ -33,11 +31,11 @@ public class HashicorpSimpleSessionManager implements SessionManager {
     this.clientAuthentication = clientAuthentication;
   }
 
-  private boolean isTokenEmptyOrExpired(){
-    if (this.token.isEmpty()){
+  private boolean isTokenEmptyOrExpired() {
+    if (this.token.isEmpty()) {
       return true;
     }
-    LoginToken loginToken = (LoginToken)this.token.get();
+    LoginToken loginToken = (LoginToken) this.token.get();
     Duration ttlAdjusted = loginToken.getLeaseDuration().minus(safetyMarginInSeconds);
     return Duration.between(tokenStartTime, Instant.now()).getSeconds() >= ttlAdjusted.getSeconds();
   }
@@ -53,8 +51,7 @@ public class HashicorpSimpleSessionManager implements SessionManager {
           this.tokenStartTime = Instant.now();
           LOGGER.info("Successfully retrieved new vault token.");
         }
-      }
-      finally {
+      } finally {
         this.lock.unlock();
       }
     }

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpSimpleSessionManager.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpSimpleSessionManager.java
@@ -35,9 +35,13 @@ public class HashicorpSimpleSessionManager implements SessionManager {
     if (this.token.isEmpty()) {
       return true;
     }
-    LoginToken loginToken = (LoginToken) this.token.get();
-    Duration ttlAdjusted = loginToken.getLeaseDuration().minus(safetyMarginInSeconds);
-    return Duration.between(tokenStartTime, Instant.now()).getSeconds() >= ttlAdjusted.getSeconds();
+    if (this.token.get() instanceof LoginToken) {
+      LoginToken loginToken = (LoginToken) this.token.get();
+      Duration ttlAdjusted = loginToken.getLeaseDuration().minus(safetyMarginInSeconds);
+      return Duration.between(tokenStartTime, Instant.now()).getSeconds()
+          >= ttlAdjusted.getSeconds();
+    }
+    return false;
   }
 
   @Override

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpSimpleSessionManager.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpSimpleSessionManager.java
@@ -1,0 +1,64 @@
+package com.quorum.tessera.key.vault.hashicorp;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
+import org.springframework.vault.authentication.ClientAuthentication;
+import org.springframework.vault.authentication.LoginToken;
+import org.springframework.vault.authentication.SessionManager;
+import org.springframework.vault.authentication.SimpleSessionManager;
+import org.springframework.vault.support.VaultToken;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class HashicorpSimpleSessionManager implements SessionManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HashicorpSimpleSessionManager.class);
+  private final ClientAuthentication clientAuthentication;
+
+  private final ReentrantLock lock = new ReentrantLock();
+
+  private volatile Optional<VaultToken> token = Optional.empty();
+  private Instant tokenStartTime;
+
+  private final Duration safetyMarginInSeconds = Duration.ofSeconds(5);
+
+  public HashicorpSimpleSessionManager(ClientAuthentication clientAuthentication) {
+
+    Assert.notNull(clientAuthentication, "ClientAuthentication must not be null");
+
+    this.clientAuthentication = clientAuthentication;
+  }
+
+  private boolean isTokenEmptyOrExpired(){
+    if (this.token.isEmpty()){
+      return true;
+    }
+    LoginToken loginToken = (LoginToken)this.token.get();
+    Duration ttlAdjusted = loginToken.getLeaseDuration().minus(safetyMarginInSeconds);
+    return Duration.between(tokenStartTime, Instant.now()).getSeconds() >= ttlAdjusted.getSeconds();
+  }
+
+  @Override
+  public VaultToken getSessionToken() {
+
+    if (isTokenEmptyOrExpired()) {
+      this.lock.lock();
+      try {
+        if (isTokenEmptyOrExpired()) {
+          this.token = Optional.of(this.clientAuthentication.login());
+          this.tokenStartTime = Instant.now();
+          LOGGER.info("Successfully retrieved new vault token.");
+        }
+      }
+      finally {
+        this.lock.unlock();
+      }
+    }
+
+    return this.token.orElseThrow(() -> new IllegalStateException("Cannot obtain VaultToken"));
+  }
+}

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
@@ -115,7 +115,7 @@ class HashicorpVaultServiceFactory {
             envVarHashicorpSecretId,
             envVarHashicorpToken);
 
-    SessionManager sessionManager = new SimpleSessionManager(clientAuthentication);
+    SessionManager sessionManager = new HashicorpSimpleSessionManager(clientAuthentication);
 
     VaultOperations vaultOperations =
         getVaultOperations(

--- a/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
+++ b/key-vault/hashicorp-key-vault/src/main/java/com/quorum/tessera/key/vault/hashicorp/HashicorpVaultServiceFactory.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.vault.authentication.ClientAuthentication;
 import org.springframework.vault.authentication.SessionManager;
-import org.springframework.vault.authentication.SimpleSessionManager;
 import org.springframework.vault.client.RestTemplateBuilder;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.core.VaultOperations;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/tessera/blob/master/.github/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
The built-in SimpleSessionManager() does not handle renewal of an expired Vault auth token. Relevant JIRA - SET-559

To address this, a custom session manager was implemented. 
Behaviour: Before calling a Vault API, it will first check whether the cached auth token is empty or have expired. **Is yes**, then it will re-authenticate with Vault to fetch a new token and cache it, **otherwise** it will  reuse the cached auth token.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
